### PR TITLE
Intersect rework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /target
 /Cargo.lock
 /bench/bench
+*.bk

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,8 +16,7 @@ done the following things first:
 4. All of the following commands completed without errors.
    * `cargo build`
    * `cargo test --all`
-5. You have granted non-exclusive right to your source code under both
-   the [Apache License 2.0][la]
+5. You have granted non-exclusive right to your source code under the [Apache License 2.0][la]
 
 [la]: LICENSE
 [st]: tests/frustum.rs

--- a/src/aabb.rs
+++ b/src/aabb.rs
@@ -36,7 +36,8 @@ pub trait MinMax {
 }
 
 impl<S> MinMax for Point2<S>
-    where S: BaseNum
+where
+    S: BaseNum,
 {
     fn min(a: Point2<S>, b: Point2<S>) -> Point2<S> {
         Point2::new(a.x.partial_min(b.x), a.y.partial_min(b.y))
@@ -48,24 +49,31 @@ impl<S> MinMax for Point2<S>
 }
 
 impl<S> MinMax for Point3<S>
-    where S: BaseNum
+where
+    S: BaseNum,
 {
     fn min(a: Point3<S>, b: Point3<S>) -> Point3<S> {
-        Point3::new(a.x.partial_min(b.x),
-                    a.y.partial_min(b.y),
-                    a.z.partial_min(b.z))
+        Point3::new(
+            a.x.partial_min(b.x),
+            a.y.partial_min(b.y),
+            a.z.partial_min(b.z),
+        )
     }
 
     fn max(a: Point3<S>, b: Point3<S>) -> Point3<S> {
-        Point3::new(a.x.partial_max(b.x),
-                    a.y.partial_max(b.y),
-                    a.z.partial_max(b.z))
+        Point3::new(
+            a.x.partial_max(b.x),
+            a.y.partial_max(b.y),
+            a.z.partial_max(b.z),
+        )
     }
 }
 
-pub trait Aabb<S: BaseNum,
-               V: VectorSpace<Scalar = S> + ElementWise + Array<Element = S>,
-               P: EuclideanSpace<Scalar = S, Diff = V>>: Sized {
+pub trait Aabb<
+    S: BaseNum,
+    V: VectorSpace<Scalar = S> + ElementWise + Array<Element = S>,
+    P: EuclideanSpace<Scalar = S, Diff = V>,
+>: Sized {
     /// Create a new AABB using two points as opposing corners.
     fn new(p1: P, p2: P) -> Self;
 
@@ -101,7 +109,8 @@ pub trait Aabb<S: BaseNum,
 
     /// Returns a new AABB that is grown to include the given point.
     fn grow(&self, p: P) -> Self
-        where P: MinMax
+    where
+        P: MinMax,
     {
         Aabb::new(MinMax::min(self.min(), p), MinMax::max(self.max(), p))
     }
@@ -145,10 +154,12 @@ impl<S: BaseNum> Aabb2<S> {
     /// Compute corners.
     #[inline]
     pub fn to_corners(&self) -> [Point2<S>; 4] {
-        [self.min,
-         Point2::new(self.max.x, self.min.y),
-         Point2::new(self.min.x, self.max.y),
-         self.max]
+        [
+            self.min,
+            Point2::new(self.max.x, self.min.y),
+            Point2::new(self.min.x, self.max.y),
+            self.max,
+        ]
     }
 }
 
@@ -195,26 +206,32 @@ impl<S: BaseNum> Aabb3<S> {
     #[inline]
     pub fn new(p1: Point3<S>, p2: Point3<S>) -> Aabb3<S> {
         Aabb3 {
-            min: Point3::new(p1.x.partial_min(p2.x),
-                             p1.y.partial_min(p2.y),
-                             p1.z.partial_min(p2.z)),
-            max: Point3::new(p1.x.partial_max(p2.x),
-                             p1.y.partial_max(p2.y),
-                             p1.z.partial_max(p2.z)),
+            min: Point3::new(
+                p1.x.partial_min(p2.x),
+                p1.y.partial_min(p2.y),
+                p1.z.partial_min(p2.z),
+            ),
+            max: Point3::new(
+                p1.x.partial_max(p2.x),
+                p1.y.partial_max(p2.y),
+                p1.z.partial_max(p2.z),
+            ),
         }
     }
 
     /// Compute corners.
     #[inline]
     pub fn to_corners(&self) -> [Point3<S>; 8] {
-        [self.min,
-         Point3::new(self.max.x, self.min.y, self.min.z),
-         Point3::new(self.min.x, self.max.y, self.min.z),
-         Point3::new(self.max.x, self.max.y, self.min.z),
-         Point3::new(self.min.x, self.min.y, self.max.z),
-         Point3::new(self.max.x, self.min.y, self.max.z),
-         Point3::new(self.min.x, self.max.y, self.max.z),
-         self.max]
+        [
+            self.min,
+            Point3::new(self.max.x, self.min.y, self.min.z),
+            Point3::new(self.min.x, self.max.y, self.min.z),
+            Point3::new(self.max.x, self.max.y, self.min.z),
+            Point3::new(self.min.x, self.min.y, self.max.z),
+            Point3::new(self.max.x, self.min.y, self.max.z),
+            Point3::new(self.min.x, self.max.y, self.max.z),
+            self.max,
+        ]
     }
 }
 
@@ -239,7 +256,7 @@ impl<S: BaseNum> Aabb<S, Vector3<S>, Point3<S>> for Aabb3<S> {
         let v_min = p - self.min();
         let v_max = self.max() - p;
         v_min.x >= S::zero() && v_min.y >= S::zero() && v_min.z >= S::zero() &&
-        v_max.x > S::zero() && v_max.y > S::zero() && v_max.z > S::zero()
+            v_max.x > S::zero() && v_max.y > S::zero() && v_max.z > S::zero()
     }
 }
 
@@ -274,11 +291,15 @@ impl<S: BaseFloat> Continuous<Point2<S>> for (Ray2<S>, Aabb2<S>) {
             None
         } else if tmax >= tmin {
             if tmin >= S::zero() {
-                Some(Point2::new(ray.origin.x + ray.direction.x * tmin,
-                                 ray.origin.y + ray.direction.y * tmin))
+                Some(Point2::new(
+                    ray.origin.x + ray.direction.x * tmin,
+                    ray.origin.y + ray.direction.y * tmin,
+                ))
             } else {
-                Some(Point2::new(ray.origin.x + ray.direction.x * tmax,
-                                 ray.origin.y + ray.direction.y * tmax))
+                Some(Point2::new(
+                    ray.origin.x + ray.direction.x * tmax,
+                    ray.origin.y + ray.direction.y * tmax,
+                ))
             }
         } else {
             None
@@ -310,13 +331,17 @@ impl<S: BaseFloat> Continuous<Point3<S>> for (Ray3<S>, Aabb3<S>) {
             None
         } else if tmax >= tmin {
             if tmin >= S::zero() {
-                Some(Point3::new(ray.origin.x + ray.direction.x * tmin,
-                                 ray.origin.y + ray.direction.y * tmin,
-                                 ray.origin.z + ray.direction.z * tmin))
+                Some(Point3::new(
+                    ray.origin.x + ray.direction.x * tmin,
+                    ray.origin.y + ray.direction.y * tmin,
+                    ray.origin.z + ray.direction.z * tmin,
+                ))
             } else {
-                Some(Point3::new(ray.origin.x + ray.direction.x * tmax,
-                                 ray.origin.y + ray.direction.y * tmax,
-                                 ray.origin.z + ray.direction.z * tmax))
+                Some(Point3::new(
+                    ray.origin.x + ray.direction.x * tmax,
+                    ray.origin.y + ray.direction.y * tmax,
+                    ray.origin.z + ray.direction.z * tmax,
+                ))
             }
         } else {
             None
@@ -330,7 +355,8 @@ impl<S: BaseFloat> Discrete for (Aabb2<S>, Aabb2<S>) {
         let (ref a, ref b) = *self;
 
         if (a.max().x <= b.min().x) || (a.min().x >= b.max().x) || (a.max().y <= b.min().y) ||
-           (a.min().y >= b.min().y) {
+            (a.min().y >= b.min().y)
+        {
             return false;
         }
         true

--- a/src/aabb.rs
+++ b/src/aabb.rs
@@ -28,7 +28,7 @@ use cgmath::{BaseNum, BaseFloat, ElementWise};
 
 use {Ray2, Ray3, Plane};
 use bound::{Bound, Relation};
-use intersect::Continuous;
+use intersect::{Continuous, Discrete};
 
 pub trait MinMax {
     fn min(a: Self, b: Self) -> Self;
@@ -323,6 +323,20 @@ impl<S: BaseFloat> Continuous<Point3<S>> for (Ray3<S>, Aabb3<S>) {
         }
     }
 }
+
+impl<S: BaseFloat> Discrete for (Aabb2<S>, Aabb2<S>) {
+    // TODO: i don't like current implementation
+    fn intersects(&self) -> bool {
+        let (ref a, ref b) = *self;
+
+        if (a.max().x <= b.min().x) || (a.min().x >= b.max().x) || (a.max().y <= b.min().y) ||
+           (a.min().y >= b.min().y) {
+            return false;
+        }
+        true
+    }
+}
+
 
 impl<S: BaseFloat + 'static> Bound<S> for Aabb3<S> {
     fn relate_plane(self, plane: Plane<S>) -> Relation {

--- a/src/aabb.rs
+++ b/src/aabb.rs
@@ -28,7 +28,7 @@ use cgmath::{BaseNum, BaseFloat, ElementWise};
 
 use {Ray2, Ray3, Plane};
 use bound::{Bound, Relation};
-use intersect::Intersect;
+use intersect::Continuous;
 
 pub trait MinMax {
     fn min(a: Self, b: Self) -> Self;
@@ -249,7 +249,7 @@ impl<S: BaseNum> fmt::Debug for Aabb3<S> {
     }
 }
 
-impl<S: BaseFloat> Intersect<Option<Point2<S>>> for (Ray2<S>, Aabb2<S>) {
+impl<S: BaseFloat> Continuous<Point2<S>> for (Ray2<S>, Aabb2<S>) {
     fn intersection(&self) -> Option<Point2<S>> {
         let (ref ray, ref aabb) = *self;
 
@@ -286,7 +286,7 @@ impl<S: BaseFloat> Intersect<Option<Point2<S>>> for (Ray2<S>, Aabb2<S>) {
     }
 }
 
-impl<S: BaseFloat> Intersect<Option<Point3<S>>> for (Ray3<S>, Aabb3<S>) {
+impl<S: BaseFloat> Continuous<Point3<S>> for (Ray3<S>, Aabb3<S>) {
     fn intersection(&self) -> Option<Point3<S>> {
         let (ref ray, ref aabb) = *self;
 

--- a/src/bound.rs
+++ b/src/bound.rs
@@ -61,9 +61,11 @@ impl<S: BaseFloat + 'static> Bound<S> for Point3<S> {
     fn relate_clip_space(self, projection: Matrix4<S>) -> Relation {
         use std::cmp::Ordering::*;
         let p = projection * self.to_homogeneous();
-        match (p.x.abs().partial_cmp(&p.w),
-               p.y.abs().partial_cmp(&p.w),
-               p.z.abs().partial_cmp(&p.w)) {
+        match (
+            p.x.abs().partial_cmp(&p.w),
+            p.y.abs().partial_cmp(&p.w),
+            p.z.abs().partial_cmp(&p.w),
+        ) {
             (Some(Less), Some(Less), Some(Less)) => Relation::In,
             (Some(Greater), _, _) |
             (_, Some(Greater), _) |

--- a/src/frustum.rs
+++ b/src/frustum.rs
@@ -35,13 +35,14 @@ pub struct Frustum<S: BaseFloat> {
 
 impl<S: BaseFloat + 'static> Frustum<S> {
     /// Construct a frustum.
-    pub fn new(left: Plane<S>,
-               right: Plane<S>,
-               bottom: Plane<S>,
-               top: Plane<S>,
-               near: Plane<S>,
-               far: Plane<S>)
-               -> Frustum<S> {
+    pub fn new(
+        left: Plane<S>,
+        right: Plane<S>,
+        bottom: Plane<S>,
+        top: Plane<S>,
+        near: Plane<S>,
+        far: Plane<S>,
+    ) -> Frustum<S> {
         Frustum {
             left: left,
             right: right,
@@ -54,36 +55,50 @@ impl<S: BaseFloat + 'static> Frustum<S> {
 
     /// Extract frustum planes from a projection matrix.
     pub fn from_matrix4(mat: Matrix4<S>) -> Option<Frustum<S>> {
-        Some(Frustum::new(match Plane::from_vector4_alt(mat.row(3) + mat.row(0)).normalize() {
-                              Some(p) => p,
-                              None => return None,
-                          },
-                          match Plane::from_vector4_alt(mat.row(3) - mat.row(0)).normalize() {
-                              Some(p) => p,
-                              None => return None,
-                          },
-                          match Plane::from_vector4_alt(mat.row(3) + mat.row(1)).normalize() {
-                              Some(p) => p,
-                              None => return None,
-                          },
-                          match Plane::from_vector4_alt(mat.row(3) - mat.row(1)).normalize() {
-                              Some(p) => p,
-                              None => return None,
-                          },
-                          match Plane::from_vector4_alt(mat.row(3) + mat.row(2)).normalize() {
-                              Some(p) => p,
-                              None => return None,
-                          },
-                          match Plane::from_vector4_alt(mat.row(3) - mat.row(2)).normalize() {
-                              Some(p) => p,
-                              None => return None,
-                          }))
+        Some(Frustum::new(
+            match Plane::from_vector4_alt(mat.row(3) + mat.row(0))
+                .normalize() {
+                Some(p) => p,
+                None => return None,
+            },
+            match Plane::from_vector4_alt(mat.row(3) - mat.row(0))
+                .normalize() {
+                Some(p) => p,
+                None => return None,
+            },
+            match Plane::from_vector4_alt(mat.row(3) + mat.row(1))
+                .normalize() {
+                Some(p) => p,
+                None => return None,
+            },
+            match Plane::from_vector4_alt(mat.row(3) - mat.row(1))
+                .normalize() {
+                Some(p) => p,
+                None => return None,
+            },
+            match Plane::from_vector4_alt(mat.row(3) + mat.row(2))
+                .normalize() {
+                Some(p) => p,
+                None => return None,
+            },
+            match Plane::from_vector4_alt(mat.row(3) - mat.row(2))
+                .normalize() {
+                Some(p) => p,
+                None => return None,
+            },
+        ))
     }
 
     /// Find the spatial relation of a bound inside this frustum.
     pub fn contains<B: Bound<S> + Copy>(&self, bound: B) -> Relation {
-        [self.left, self.right, self.top, self.bottom, self.near, self.far]
-            .iter()
+        [
+            self.left,
+            self.right,
+            self.top,
+            self.bottom,
+            self.near,
+            self.far,
+        ].iter()
             .fold(Relation::In, |cur, p| {
                 use std::cmp::max;
                 let r = bound.relate_plane(*p);

--- a/src/intersect.rs
+++ b/src/intersect.rs
@@ -40,6 +40,14 @@ impl<S: BaseFloat> Continuous<Point3<S>> for (Plane<S>, Ray3<S>) {
     }
 }
 
+impl<S: BaseFloat> Discrete for (Plane<S>, Ray3<S>) {
+    fn intersects(&self) -> bool {
+        let (ref p, ref r) = *self;
+        let t = -(p.d + r.origin.dot(p.n)) / r.direction.dot(p.n);
+        return t >= Zero::zero();
+    }
+}
+
 /// See _Real-Time Collision Detection_, p. 210
 impl<S: BaseFloat> Continuous<Ray3<S>> for (Plane<S>, Plane<S>) {
     fn intersection(&self) -> Option<Ray3<S>> {
@@ -55,6 +63,15 @@ impl<S: BaseFloat> Continuous<Ray3<S>> for (Plane<S>, Plane<S>) {
     }
 }
 
+impl<S: BaseFloat> Discrete for (Plane<S>, Plane<S>) {
+    fn intersects(&self) -> bool {
+        let (ref p1, ref p2) = *self;
+        let d = p1.n.cross(p2.n);
+        let denom = d.dot(d);
+        return !ulps_eq!(denom, &S::zero());
+    }
+}
+
 /// See _Real-Time Collision Detection_, p. 212 - 214
 impl<S: BaseFloat> Continuous<Point3<S>> for (Plane<S>, Plane<S>, Plane<S>) {
     fn intersection(&self) -> Option<Point3<S>> {
@@ -67,6 +84,15 @@ impl<S: BaseFloat> Continuous<Point3<S>> for (Plane<S>, Plane<S>, Plane<S>) {
             let p = (u * p1.d + p1.n.cross(p2.n * p3.d - p3.n * p2.d)) / denom;
             Some(Point3::from_vec(p))
         }
+    }
+}
+
+impl<S: BaseFloat> Discrete for (Plane<S>, Plane<S>, Plane<S>) {
+    fn intersects(&self) -> bool {
+        let (ref p1, ref p2, ref p3) = *self;
+        let u = p2.n.cross(p3.n);
+        let denom = p1.n.dot(u);
+        return !ulps_eq!(denom.abs(), &S::zero());
     }
 }
 

--- a/src/intersect.rs
+++ b/src/intersect.rs
@@ -22,6 +22,10 @@ pub trait Continuous<Result> {
     fn intersection(&self) -> Option<Result>;
 }
 
+pub trait Discrete {
+    fn intersects(&self) -> bool;
+}
+
 
 impl<S: BaseFloat> Continuous<Point3<S>> for (Plane<S>, Ray3<S>) {
     fn intersection(&self) -> Option<Point3<S>> {

--- a/src/intersect.rs
+++ b/src/intersect.rs
@@ -121,7 +121,8 @@ impl<S: BaseFloat> Continuous<Point2<S>> for (Ray2<S>, Line2<S>) {
             let dot_1 = qmp.dot(r);
             let dot_2 = q2mp.dot(r);
             if (dot_1 <= S::zero() && dot_2 >= S::zero()) ||
-               (dot_1 >= S::zero() && dot_2 <= S::zero()) {
+                (dot_1 >= S::zero() && dot_2 <= S::zero())
+            {
                 return Some(p);
             } else if dot_1 >= S::zero() && dot_2 >= S::zero() {
                 if dot_1 <= dot_2 {

--- a/src/intersect.rs
+++ b/src/intersect.rs
@@ -18,12 +18,12 @@ use cgmath::{BaseFloat, Zero, EuclideanSpace};
 use cgmath::{Point2, Point3};
 use cgmath::{InnerSpace, Vector2};
 
-pub trait Intersect<Result> {
-    fn intersection(&self) -> Result;
+pub trait Continuous<Result> {
+    fn intersection(&self) -> Option<Result>;
 }
 
 
-impl<S: BaseFloat> Intersect<Option<Point3<S>>> for (Plane<S>, Ray3<S>) {
+impl<S: BaseFloat> Continuous<Point3<S>> for (Plane<S>, Ray3<S>) {
     fn intersection(&self) -> Option<Point3<S>> {
         let (ref p, ref r) = *self;
 
@@ -37,7 +37,7 @@ impl<S: BaseFloat> Intersect<Option<Point3<S>>> for (Plane<S>, Ray3<S>) {
 }
 
 /// See _Real-Time Collision Detection_, p. 210
-impl<S: BaseFloat> Intersect<Option<Ray3<S>>> for (Plane<S>, Plane<S>) {
+impl<S: BaseFloat> Continuous<Ray3<S>> for (Plane<S>, Plane<S>) {
     fn intersection(&self) -> Option<Ray3<S>> {
         let (p1, p2) = *self;
         let d = p1.n.cross(p2.n);
@@ -52,7 +52,7 @@ impl<S: BaseFloat> Intersect<Option<Ray3<S>>> for (Plane<S>, Plane<S>) {
 }
 
 /// See _Real-Time Collision Detection_, p. 212 - 214
-impl<S: BaseFloat> Intersect<Option<Point3<S>>> for (Plane<S>, Plane<S>, Plane<S>) {
+impl<S: BaseFloat> Continuous<Point3<S>> for (Plane<S>, Plane<S>, Plane<S>) {
     fn intersection(&self) -> Option<Point3<S>> {
         let (p1, p2, p3) = *self;
         let u = p2.n.cross(p3.n);
@@ -67,7 +67,7 @@ impl<S: BaseFloat> Intersect<Option<Point3<S>>> for (Plane<S>, Plane<S>, Plane<S
 }
 
 /// Determines if an intersection between a ray and a line segment is found.
-impl<S: BaseFloat> Intersect<Option<Point2<S>>> for (Ray2<S>, Line2<S>) {
+impl<S: BaseFloat> Continuous<Point2<S>> for (Ray2<S>, Line2<S>) {
     fn intersection(&self) -> Option<Point2<S>> {
         let (ref ray, ref line) = *self;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,7 @@ pub use aabb::*;
 pub use bound::*;
 pub use cylinder::Cylinder;
 pub use frustum::{Frustum, FrustumPoints, Projection};
-pub use intersect::Intersect;
+pub use intersect::Continuous;
 pub use obb::*;
 pub use sphere::Sphere;
 pub use plane::Plane;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,7 @@ pub use bound::*;
 pub use cylinder::Cylinder;
 pub use frustum::{Frustum, FrustumPoints, Projection};
 pub use intersect::Continuous;
+pub use intersect::Discrete;
 pub use obb::*;
 pub use sphere::Sphere;
 pub use plane::Plane;

--- a/src/line.rs
+++ b/src/line.rs
@@ -31,9 +31,8 @@ pub struct Line<S, V, P> {
     phantom_v: PhantomData<V>,
 }
 
-impl<S: BaseNum, V: VectorSpace<Scalar = S>, P: EuclideanSpace<Scalar = S, Diff = V>> Line<S,
-                                                                                           V,
-                                                                                           P> {
+impl<S: BaseNum, V: VectorSpace<Scalar = S>, P: EuclideanSpace<Scalar = S, Diff = V>>
+    Line<S, V, P> {
     pub fn new(origin: P, dest: P) -> Line<S, V, P> {
         Line {
             origin: origin,

--- a/src/plane.rs
+++ b/src/plane.rs
@@ -105,10 +105,7 @@ impl<S: BaseFloat> Plane<S> {
     /// Construct a plane from a point and a normal vector.
     /// The plane will contain the point `p` and be perpendicular to `n`.
     pub fn from_point_normal(p: Point3<S>, n: Vector3<S>) -> Plane<S> {
-        Plane {
-            n: n,
-            d: p.dot(n),
-        }
+        Plane { n: n, d: p.dot(n) }
     }
 
     /// Normalize a plane.
@@ -123,7 +120,8 @@ impl<S: BaseFloat> Plane<S> {
 }
 
 impl<S> ApproxEq for Plane<S>
-    where S: BaseFloat
+where
+    S: BaseFloat,
 {
     type Epsilon = S::Epsilon;
 
@@ -145,23 +143,25 @@ impl<S> ApproxEq for Plane<S>
     #[inline]
     fn relative_eq(&self, other: &Self, epsilon: S::Epsilon, max_relative: S::Epsilon) -> bool {
         Vector3::relative_eq(&self.n, &other.n, epsilon, max_relative) &&
-        S::relative_eq(&self.d, &other.d, epsilon, max_relative)
+            S::relative_eq(&self.d, &other.d, epsilon, max_relative)
     }
 
     #[inline]
     fn ulps_eq(&self, other: &Self, epsilon: S::Epsilon, max_ulps: u32) -> bool {
         Vector3::ulps_eq(&self.n, &other.n, epsilon, max_ulps) &&
-        S::ulps_eq(&self.d, &other.d, epsilon, max_ulps)
+            S::ulps_eq(&self.d, &other.d, epsilon, max_ulps)
     }
 }
 
 impl<S: BaseFloat> fmt::Debug for Plane<S> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f,
-               "{:?}x + {:?}y + {:?}z - {:?} = 0",
-               self.n.x,
-               self.n.y,
-               self.n.z,
-               self.d)
+        write!(
+            f,
+            "{:?}x + {:?}y + {:?}z - {:?} = 0",
+            self.n.x,
+            self.n.y,
+            self.n.z,
+            self.d
+        )
     }
 }

--- a/src/ray.rs
+++ b/src/ray.rs
@@ -29,9 +29,10 @@ pub struct Ray<S, P, V> {
 }
 
 impl<S, V, P> Ray<S, P, V>
-    where S: BaseNum,
-          V: VectorSpace<Scalar = S>,
-          P: EuclideanSpace<Scalar = S, Diff = V>
+where
+    S: BaseNum,
+    V: VectorSpace<Scalar = S>,
+    P: EuclideanSpace<Scalar = S, Diff = V>,
 {
     pub fn new(origin: P, direction: V) -> Ray<S, P, V> {
         Ray {

--- a/src/sphere.rs
+++ b/src/sphere.rs
@@ -16,7 +16,7 @@
 //! Bounding sphere
 
 use bound::*;
-use intersect::Intersect;
+use intersect::Continuous;
 use Plane;
 use Ray3;
 use cgmath::{BaseFloat, EuclideanSpace};
@@ -29,7 +29,7 @@ pub struct Sphere<S: BaseFloat> {
     pub radius: S,
 }
 
-impl<S: BaseFloat> Intersect<Option<Point3<S>>> for (Sphere<S>, Ray3<S>) {
+impl<S: BaseFloat> Continuous<Point3<S>> for (Sphere<S>, Ray3<S>) {
     fn intersection(&self) -> Option<Point3<S>> {
         let (ref s, ref r) = *self;
 

--- a/src/sphere.rs
+++ b/src/sphere.rs
@@ -16,11 +16,11 @@
 //! Bounding sphere
 
 use bound::*;
-use intersect::Continuous;
+use intersect::{Continuous, Discrete};
 use Plane;
 use Ray3;
 use cgmath::{BaseFloat, EuclideanSpace};
-use cgmath::{InnerSpace, Point3};
+use cgmath::{InnerSpace, Point3, MetricSpace};
 
 #[derive(Copy, Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "eders", derive(Serialize, Deserialize))]
@@ -44,6 +44,17 @@ impl<S: BaseFloat> Continuous<Point3<S>> for (Sphere<S>, Ray3<S>) {
         }
         let thc = (s.radius * s.radius - d2).sqrt();
         Some(r.origin + r.direction * (tca - thc))
+    }
+}
+
+impl<S: BaseFloat> Discrete for (Sphere<S>, Sphere<S>) {
+    fn intersects(&self) -> bool {
+        let (ref s1, ref s2) = *self;
+
+        let distance = s1.center.distance2(s2.center);
+        let radiuses = s1.radius + s2.radius;
+        
+        distance <= radiuses
     }
 }
 

--- a/src/sphere.rs
+++ b/src/sphere.rs
@@ -47,13 +47,29 @@ impl<S: BaseFloat> Continuous<Point3<S>> for (Sphere<S>, Ray3<S>) {
     }
 }
 
+impl<S: BaseFloat> Discrete for (Sphere<S>, Ray3<S>) {
+    fn intersects(&self) -> bool {
+        let (ref s, ref r) = *self;
+        let l = s.center - r.origin;
+        let tca = l.dot(r.direction);
+        if tca < S::zero() {
+            return false;
+        }
+        let d2 = l.dot(l) - tca * tca;
+        if d2 > s.radius * s.radius {
+            return false;
+        }
+        return true;
+    }
+}
+
 impl<S: BaseFloat> Discrete for (Sphere<S>, Sphere<S>) {
     fn intersects(&self) -> bool {
         let (ref s1, ref s2) = *self;
 
         let distance = s1.center.distance2(s2.center);
         let radiuses = s1.radius + s2.radius;
-        
+
         distance <= radiuses
     }
 }

--- a/tests/aabb.rs
+++ b/tests/aabb.rs
@@ -25,8 +25,10 @@ use cgmath::{Vector2, Vector3};
 
 #[test]
 fn test_general() {
-    let aabb = Aabb2::new(Point2::new(-20isize, 30isize),
-                          Point2::new(10isize, -10isize));
+    let aabb = Aabb2::new(
+        Point2::new(-20isize, 30isize),
+        Point2::new(10isize, -10isize),
+    );
     assert_eq!(aabb.min(), Point2::new(-20isize, -10isize));
     assert_eq!(aabb.max(), Point2::new(10isize, 30isize));
     assert_eq!(aabb.dim(), Vector2::new(30isize, 40isize));
@@ -38,15 +40,25 @@ fn test_general() {
     assert!(!aabb.contains(Point2::new(50isize, 50isize)));
 
     assert_eq!(aabb.grow(Point2::new(0isize, 0isize)), aabb);
-    assert_eq!(aabb.grow(Point2::new(100isize, 100isize)),
-               Aabb2::new(Point2::new(-20isize, -10isize),
-                          Point2::new(100isize, 100isize)));
-    assert_eq!(aabb.grow(Point2::new(-100isize, -100isize)),
-               Aabb2::new(Point2::new(-100isize, -100isize),
-                          Point2::new(10isize, 30isize)));
+    assert_eq!(
+        aabb.grow(Point2::new(100isize, 100isize)),
+        Aabb2::new(
+            Point2::new(-20isize, -10isize),
+            Point2::new(100isize, 100isize),
+        )
+    );
+    assert_eq!(
+        aabb.grow(Point2::new(-100isize, -100isize)),
+        Aabb2::new(
+            Point2::new(-100isize, -100isize),
+            Point2::new(10isize, 30isize),
+        )
+    );
 
-    let aabb = Aabb3::new(Point3::new(-20isize, 30isize, 5isize),
-                          Point3::new(10isize, -10isize, -5isize));
+    let aabb = Aabb3::new(
+        Point3::new(-20isize, 30isize, 5isize),
+        Point3::new(10isize, -10isize, -5isize),
+    );
     assert_eq!(aabb.min(), Point3::new(-20isize, -10isize, -5isize));
     assert_eq!(aabb.max(), Point3::new(10isize, 30isize, 5isize));
     assert_eq!(aabb.dim(), Vector3::new(30isize, 40isize, 10isize));
@@ -61,17 +73,29 @@ fn test_general() {
     assert!(aabb.contains(Point3::new(-20isize, -10isize, -5isize)));
     assert!(!aabb.contains(Point3::new(-21isize, -11isize, -6isize)));
 
-    assert_eq!(aabb.add_v(Vector3::new(1isize, 2isize, 3isize)),
-               Aabb3::new(Point3::new(-19isize, 32isize, 8isize),
-                          Point3::new(11isize, -8isize, -2isize)));
+    assert_eq!(
+        aabb.add_v(Vector3::new(1isize, 2isize, 3isize)),
+        Aabb3::new(
+            Point3::new(-19isize, 32isize, 8isize),
+            Point3::new(11isize, -8isize, -2isize),
+        )
+    );
 
-    assert_eq!(aabb.mul_s(2isize),
-               Aabb3::new(Point3::new(-40isize, -20isize, -10isize),
-                          Point3::new(20isize, 60isize, 10isize)));
+    assert_eq!(
+        aabb.mul_s(2isize),
+        Aabb3::new(
+            Point3::new(-40isize, -20isize, -10isize),
+            Point3::new(20isize, 60isize, 10isize),
+        )
+    );
 
-    assert_eq!(aabb.mul_v(Vector3::new(1isize, 2isize, 3isize)),
-               Aabb3::new(Point3::new(-20isize, -20isize, -15isize),
-                          Point3::new(10isize, 60isize, 15isize)));
+    assert_eq!(
+        aabb.mul_v(Vector3::new(1isize, 2isize, 3isize)),
+        Aabb3::new(
+            Point3::new(-20isize, -20isize, -15isize),
+            Point3::new(10isize, 60isize, 15isize),
+        )
+    );
 }
 
 #[test]
@@ -94,8 +118,10 @@ fn test_parallel_ray3_should_not_intersect() {
     let ray_x = Ray::new(Point3::new(0.0f32, 0.0, 0.0), Vector3::new(1.0, 0.0, 0.0));
     let ray_y = Ray::new(Point3::new(0.0f32, 0.0, 0.0), Vector3::new(0.0, 1.0, 0.0));
     let ray_z = Ray::new(Point3::new(0.0f32, 0.0, 0.0), Vector3::new(0.0, 0.0, 1.0));
-    let ray_z_imprecise = Ray::new(Point3::new(0.0f32, 0.0, 0.0),
-                                   Vector3::new(0.0001, 0.0001, 1.0));
+    let ray_z_imprecise = Ray::new(
+        Point3::new(0.0f32, 0.0, 0.0),
+        Vector3::new(0.0001, 0.0001, 1.0),
+    );
 
     assert_eq!((ray_x, aabb).intersection(), None);
     assert_eq!((ray_y, aabb).intersection(), None);
@@ -106,25 +132,37 @@ fn test_parallel_ray3_should_not_intersect() {
 #[test]
 fn test_oblique_ray3_should_intersect() {
     let aabb = Aabb3::<f32>::new(Point3::new(1.0, 1.0, 1.0), Point3::new(5.0, 5.0, 5.0));
-    let ray1 = Ray::new(Point3::new(0.0f32, 0.0, 0.0),
-                        Vector3::new(1.0, 1.0, 1.0).normalize());
+    let ray1 = Ray::new(
+        Point3::new(0.0f32, 0.0, 0.0),
+        Vector3::new(1.0, 1.0, 1.0).normalize(),
+    );
     let ray2 = Ray::new(Point3::new(0.0f32, 6.0, 0.0), Vector3::new(1.0, -1.0, 1.0));
 
-    assert_eq!((ray1, aabb).intersection(),
-               Some(Point3::new(1.0, 1.0, 1.0)));
-    assert_eq!((ray2, aabb).intersection(),
-               Some(Point3::new(1.0, 5.0, 1.0)));
+    assert_eq!(
+        (ray1, aabb).intersection(),
+        Some(Point3::new(1.0, 1.0, 1.0))
+    );
+    assert_eq!(
+        (ray2, aabb).intersection(),
+        Some(Point3::new(1.0, 5.0, 1.0))
+    );
 }
 
 #[test]
 fn test_pointing_to_other_dir_ray3_should_not_intersect() {
     let aabb = Aabb3::<f32>::new(Point3::new(1.0, 1.0, 1.0), Point3::new(5.0, 5.0, 5.0));
-    let ray_x = Ray::new(Point3::new(0.0f32, 2.0, 2.0),
-                         Vector3::new(-1.0, 0.01, 0.01));
-    let ray_y = Ray::new(Point3::new(2.0f32, 0.0, 2.0),
-                         Vector3::new(0.01, -1.0, 0.01));
-    let ray_z = Ray::new(Point3::new(2.0f32, 2.0, 0.0),
-                         Vector3::new(0.01, 0.01, -1.0));
+    let ray_x = Ray::new(
+        Point3::new(0.0f32, 2.0, 2.0),
+        Vector3::new(-1.0, 0.01, 0.01),
+    );
+    let ray_y = Ray::new(
+        Point3::new(2.0f32, 0.0, 2.0),
+        Vector3::new(0.01, -1.0, 0.01),
+    );
+    let ray_z = Ray::new(
+        Point3::new(2.0f32, 2.0, 0.0),
+        Vector3::new(0.01, 0.01, -1.0),
+    );
 
     let ray_x2 = Ray::new(Point3::new(6.0f32, 2.0, 2.0), Vector3::new(1.0, 0.0, 0.0));
     let ray_y2 = Ray::new(Point3::new(2.0f32, 6.0, 2.0), Vector3::new(0.0, 1.0, 0.0));
@@ -150,19 +188,31 @@ fn test_pointing_to_box_dir_ray3_should_intersect() {
     let ray_y2 = Ray::new(Point3::new(2.0f32, 6.0, 2.0), Vector3::new(0.0, -1.0, 0.0));
     let ray_z2 = Ray::new(Point3::new(2.0f32, 2.0, 6.0), Vector3::new(0.0, 0.0, -1.0));
 
-    assert_eq!((ray_x, aabb).intersection(),
-               Some(Point3::new(1.0, 2.0, 2.0)));
-    assert_eq!((ray_y, aabb).intersection(),
-               Some(Point3::new(2.0, 1.0, 2.0)));
-    assert_eq!((ray_z, aabb).intersection(),
-               Some(Point3::new(2.0, 2.0, 1.0)));
+    assert_eq!(
+        (ray_x, aabb).intersection(),
+        Some(Point3::new(1.0, 2.0, 2.0))
+    );
+    assert_eq!(
+        (ray_y, aabb).intersection(),
+        Some(Point3::new(2.0, 1.0, 2.0))
+    );
+    assert_eq!(
+        (ray_z, aabb).intersection(),
+        Some(Point3::new(2.0, 2.0, 1.0))
+    );
 
-    assert_eq!((ray_x2, aabb).intersection(),
-               Some(Point3::new(5.0, 2.0, 2.0)));
-    assert_eq!((ray_y2, aabb).intersection(),
-               Some(Point3::new(2.0, 5.0, 2.0)));
-    assert_eq!((ray_z2, aabb).intersection(),
-               Some(Point3::new(2.0, 2.0, 5.0)));
+    assert_eq!(
+        (ray_x2, aabb).intersection(),
+        Some(Point3::new(5.0, 2.0, 2.0))
+    );
+    assert_eq!(
+        (ray_y2, aabb).intersection(),
+        Some(Point3::new(2.0, 5.0, 2.0))
+    );
+    assert_eq!(
+        (ray_z2, aabb).intersection(),
+        Some(Point3::new(2.0, 2.0, 5.0))
+    );
 }
 
 #[test]
@@ -171,9 +221,10 @@ fn test_corners() {
     assert!(corners.contains(&Point2::new(-5f32, 10.0)));
     assert!(corners.contains(&Point2::new(5f32, 5.0)));
 
-    let corners = Aabb3::new(Point3::new(-20isize, 30isize, 5isize),
-                             Point3::new(10isize, -10isize, -5isize))
-            .to_corners();
+    let corners = Aabb3::new(
+        Point3::new(-20isize, 30isize, 5isize),
+        Point3::new(10isize, -10isize, -5isize),
+    ).to_corners();
     assert!(corners.contains(&Point3::new(-20isize, 30isize, -5isize)));
     assert!(corners.contains(&Point3::new(10isize, 30isize, 5isize)));
     assert!(corners.contains(&Point3::new(10isize, -10isize, 5isize)));
@@ -182,12 +233,12 @@ fn test_corners() {
 #[test]
 fn test_bound() {
     let aabb = Aabb3::new(Point3::new(-5.0f32, 5.0, 0.0), Point3::new(5.0, 10.0, 1.0));
-    let plane1 = Plane::from_point_normal(Point3::new(0f32, 0.0, 0.0),
-                                          Vector3::new(0f32, 0.0, 1.0));
-    let plane2 = Plane::from_point_normal(Point3::new(-5.0f32, 4.0, 0.0),
-                                          Vector3::new(0f32, 1.0, 0.0));
-    let plane3 = Plane::from_point_normal(Point3::new(6.0f32, 0.0, 0.0),
-                                          Vector3::new(1f32, 0.0, 0.0));
+    let plane1 =
+        Plane::from_point_normal(Point3::new(0f32, 0.0, 0.0), Vector3::new(0f32, 0.0, 1.0));
+    let plane2 =
+        Plane::from_point_normal(Point3::new(-5.0f32, 4.0, 0.0), Vector3::new(0f32, 1.0, 0.0));
+    let plane3 =
+        Plane::from_point_normal(Point3::new(6.0f32, 0.0, 0.0), Vector3::new(1f32, 0.0, 0.0));
     assert_eq!(aabb.relate_plane(plane1), Relation::Cross);
     assert_eq!(aabb.relate_plane(plane2), Relation::In);
     assert_eq!(aabb.relate_plane(plane3), Relation::Out);

--- a/tests/aabb.rs
+++ b/tests/aabb.rs
@@ -18,7 +18,7 @@ extern crate collision;
 
 use collision::{Aabb, Aabb2, Aabb3};
 use collision::{Bound, Relation, Plane, Ray};
-use collision::Intersect;
+use collision::Continuous;
 use cgmath::InnerSpace;
 use cgmath::{Point2, Point3};
 use cgmath::{Vector2, Vector3};

--- a/tests/frustum.rs
+++ b/tests/frustum.rs
@@ -22,25 +22,30 @@ use collision::{Projection, Relation, Sphere};
 #[test]
 fn test_contains() {
     let frustum = PerspectiveFov {
-            fovy: Rad(1f32),
-            aspect: 1f32,
-            near: 1f32,
-            far: 10f32,
-        }
-        .to_frustum();
-    assert_eq!(frustum.contains(Sphere {
-                                    center: Point3::new(0f32, 0f32, -5f32),
-                                    radius: 1f32,
-                                }),
-               Relation::In);
-    assert_eq!(frustum.contains(Sphere {
-                                    center: Point3::new(0f32, 3f32, -5f32),
-                                    radius: 1f32,
-                                }),
-               Relation::Cross);
-    assert_eq!(frustum.contains(Sphere {
-                                    center: Point3::new(0f32, 0f32, 5f32),
-                                    radius: 1f32,
-                                }),
-               Relation::Out);
+        fovy: Rad(1f32),
+        aspect: 1f32,
+        near: 1f32,
+        far: 10f32,
+    }.to_frustum();
+    assert_eq!(
+        frustum.contains(Sphere {
+            center: Point3::new(0f32, 0f32, -5f32),
+            radius: 1f32,
+        }),
+        Relation::In
+    );
+    assert_eq!(
+        frustum.contains(Sphere {
+            center: Point3::new(0f32, 3f32, -5f32),
+            radius: 1f32,
+        }),
+        Relation::Cross
+    );
+    assert_eq!(
+        frustum.contains(Sphere {
+            center: Point3::new(0f32, 0f32, 5f32),
+            radius: 1f32,
+        }),
+        Relation::Out
+    );
 }

--- a/tests/plane.rs
+++ b/tests/plane.rs
@@ -25,31 +25,44 @@ use collision::*;
 
 #[test]
 fn test_from_points() {
-    assert_eq!(Plane::from_points(Point3::new(5.0f64, 0.0f64, 5.0f64),
-                                  Point3::new(5.0f64, 5.0f64, 5.0f64),
-                                  Point3::new(5.0f64, 0.0f64, -1.0f64)),
-               Some(Plane::from_abcd(-1.0f64, 0.0f64, 0.0f64, 5.0f64)));
+    assert_eq!(
+        Plane::from_points(
+            Point3::new(5.0f64, 0.0f64, 5.0f64),
+            Point3::new(5.0f64, 5.0f64, 5.0f64),
+            Point3::new(5.0f64, 0.0f64, -1.0f64),
+        ),
+        Some(Plane::from_abcd(-1.0f64, 0.0f64, 0.0f64, 5.0f64))
+    );
 
-    assert_eq!(Plane::from_points(Point3::new(0.0f64, 5.0f64, -5.0f64),
-                                  Point3::new(0.0f64, 5.0f64, 0.0f64),
-                                  Point3::new(0.0f64, 5.0f64, 5.0f64)),
-               None); // The points are parallel
+    assert_eq!(
+        Plane::from_points(
+            Point3::new(0.0f64, 5.0f64, -5.0f64),
+            Point3::new(0.0f64, 5.0f64, 0.0f64),
+            Point3::new(0.0f64, 5.0f64, 5.0f64),
+        ),
+        None
+    ); // The points are parallel
 }
 
 #[test]
 fn test_ray_intersection() {
     let p0 = Plane::from_abcd(1f64, 0f64, 0f64, -7f64);
-    let r0: Ray3<f64> = Ray::new(Point3::new(2f64, 3f64, 4f64),
-                                 Vector3::new(1f64, 1f64, 1f64).normalize());
+    let r0: Ray3<f64> = Ray::new(
+        Point3::new(2f64, 3f64, 4f64),
+        Vector3::new(1f64, 1f64, 1f64).normalize(),
+    );
     assert!((p0, r0).intersects());
     assert_eq!((p0, r0).intersection(), Some(Point3::new(7f64, 8f64, 9f64)));
 
-    let p1 = Plane::from_points(Point3::new(5f64, 0f64, 5f64),
-                                Point3::new(5f64, 5f64, 5f64),
-                                Point3::new(5f64, 0f64, -1f64))
-            .unwrap();
-    let r1: Ray3<f64> = Ray::new(Point3::new(0f64, 0f64, 0f64),
-                                 Vector3::new(-1f64, 0f64, 0f64).normalize());
+    let p1 = Plane::from_points(
+        Point3::new(5f64, 0f64, 5f64),
+        Point3::new(5f64, 5f64, 5f64),
+        Point3::new(5f64, 0f64, -1f64),
+    ).unwrap();
+    let r1: Ray3<f64> = Ray::new(
+        Point3::new(0f64, 0f64, 0f64),
+        Vector3::new(-1f64, 0f64, 0f64).normalize(),
+    );
     assert_eq!((p1, r1).intersection(), None); // r1 points away from p1
     assert!(!(p1, r1).intersects());
 }

--- a/tests/plane.rs
+++ b/tests/plane.rs
@@ -41,6 +41,7 @@ fn test_ray_intersection() {
     let p0 = Plane::from_abcd(1f64, 0f64, 0f64, -7f64);
     let r0: Ray3<f64> = Ray::new(Point3::new(2f64, 3f64, 4f64),
                                  Vector3::new(1f64, 1f64, 1f64).normalize());
+    assert!((p0, r0).intersects());
     assert_eq!((p0, r0).intersection(), Some(Point3::new(7f64, 8f64, 9f64)));
 
     let p1 = Plane::from_points(Point3::new(5f64, 0f64, 5f64),
@@ -50,6 +51,7 @@ fn test_ray_intersection() {
     let r1: Ray3<f64> = Ray::new(Point3::new(0f64, 0f64, 0f64),
                                  Vector3::new(-1f64, 0f64, 0f64).normalize());
     assert_eq!((p1, r1).intersection(), None); // r1 points away from p1
+    assert!(!(p1, r1).intersects());
 }
 
 #[test]
@@ -58,6 +60,7 @@ fn test_plane2_intersection() {
     let p1 = Plane::new(Vector3::unit_y(), 2.0f64);
     let ray = (p0, p1).intersection();
     assert!(ray.is_some());
+    assert!((p0, p1).intersects());
 
     let ray = ray.unwrap();
     assert_ulps_eq!(ray.origin.x, &1.0f64);
@@ -71,6 +74,7 @@ fn test_plane2_intersection() {
     let p1 = Plane::new(Vector3::unit_y(), 2.0f64);
     let ray = (p0, p1).intersection();
     assert!(ray.is_none());
+    assert!(!(p0, p1).intersects());
 }
 
 #[test]
@@ -80,6 +84,7 @@ fn test_plane3_intersection() {
     let p2 = Plane::new(Vector3::unit_z(), 3.0f64);
     let point = (p0, p1, p2).intersection();
     assert!(point.is_some());
+    assert!((p0, p1, p2).intersects());
 
     let point = point.unwrap();
     assert_ulps_eq!(point.x, &1.0f64);
@@ -91,4 +96,5 @@ fn test_plane3_intersection() {
     let p2 = Plane::new(Vector3::unit_z(), 3.0f64);
     let point = (p0, p1, p2).intersection();
     assert!(point.is_none());
+    assert!(!(p0, p1, p2).intersects());
 }

--- a/tests/sphere.rs
+++ b/tests/sphere.rs
@@ -39,11 +39,15 @@ fn test_intersection() {
                       Vector3::new(0f64, 0f64, -5f64).normalize());
     assert_eq!((sphere, r0).intersection(),
                Some(Point3::new(0f64, 0f64, 1f64)));
+    assert!((sphere, r0).intersects());
     assert_ulps_eq!((sphere, r1).intersection().unwrap(),
                     &Point3::new(1f64.cos(), 0f64, 1f64.sin()));
+    assert!((sphere, r1).intersects());
     assert_eq!((sphere, r2).intersection(),
                Some(Point3::new(1f64, 0f64, 0f64)));
+    assert!((sphere, r2).intersects());
     assert_eq!((sphere, r3).intersection(), None);
+    assert!(!(sphere, r3).intersects());
 }
 
 #[test]

--- a/tests/sphere.rs
+++ b/tests/sphere.rs
@@ -29,22 +29,36 @@ fn test_intersection() {
         center: Point3::new(0f64, 0f64, 0f64),
         radius: 1f64,
     };
-    let r0 = Ray::new(Point3::new(0f64, 0f64, 5f64),
-                      Vector3::new(0f64, 0f64, -5f64).normalize());
-    let r1 = Ray::new(Point3::new(1f64.cos(), 0f64, 5f64),
-                      Vector3::new(0f64, 0f64, -5f64).normalize());
-    let r2 = Ray::new(Point3::new(1f64, 0f64, 5f64),
-                      Vector3::new(0f64, 0f64, -5f64).normalize());
-    let r3 = Ray::new(Point3::new(2f64, 0f64, 5f64),
-                      Vector3::new(0f64, 0f64, -5f64).normalize());
-    assert_eq!((sphere, r0).intersection(),
-               Some(Point3::new(0f64, 0f64, 1f64)));
+    let r0 = Ray::new(
+        Point3::new(0f64, 0f64, 5f64),
+        Vector3::new(0f64, 0f64, -5f64).normalize(),
+    );
+    let r1 = Ray::new(
+        Point3::new(1f64.cos(), 0f64, 5f64),
+        Vector3::new(0f64, 0f64, -5f64).normalize(),
+    );
+    let r2 = Ray::new(
+        Point3::new(1f64, 0f64, 5f64),
+        Vector3::new(0f64, 0f64, -5f64).normalize(),
+    );
+    let r3 = Ray::new(
+        Point3::new(2f64, 0f64, 5f64),
+        Vector3::new(0f64, 0f64, -5f64).normalize(),
+    );
+    assert_eq!(
+        (sphere, r0).intersection(),
+        Some(Point3::new(0f64, 0f64, 1f64))
+    );
     assert!((sphere, r0).intersects());
-    assert_ulps_eq!((sphere, r1).intersection().unwrap(),
-                    &Point3::new(1f64.cos(), 0f64, 1f64.sin()));
+    assert_ulps_eq!(
+        (sphere, r1).intersection().unwrap(),
+        &Point3::new(1f64.cos(), 0f64, 1f64.sin())
+    );
     assert!((sphere, r1).intersects());
-    assert_eq!((sphere, r2).intersection(),
-               Some(Point3::new(1f64, 0f64, 0f64)));
+    assert_eq!(
+        (sphere, r2).intersection(),
+        Some(Point3::new(1f64, 0f64, 0f64))
+    );
     assert!((sphere, r2).intersects());
     assert_eq!((sphere, r3).intersection(), None);
     assert!(!(sphere, r3).intersects());
@@ -59,10 +73,16 @@ fn test_bound() {
     };
     let normal = vec3(0f32, 0.0, 1.0);
 
-    assert_eq!(sphere.relate_plane(Plane::from_point_normal(point, normal)),
-               Relation::Cross);
-    assert_eq!(sphere.relate_plane(Plane::from_point_normal(point + normal * -3.0, normal)),
-               Relation::In);
-    assert_eq!(sphere.relate_plane(Plane::from_point_normal(point + normal * 3.0, normal)),
-               Relation::Out);
+    assert_eq!(
+        sphere.relate_plane(Plane::from_point_normal(point, normal)),
+        Relation::Cross
+    );
+    assert_eq!(
+        sphere.relate_plane(Plane::from_point_normal(point + normal * -3.0, normal)),
+        Relation::In
+    );
+    assert_eq!(
+        sphere.relate_plane(Plane::from_point_normal(point + normal * 3.0, normal)),
+        Relation::Out
+    );
 }


### PR DESCRIPTION
`Intersect` trait was removed and replaced with `Continuous` and `Discrete` traits according to #2.
For now they're implemented only for a few types.
Fixes #2 