### PR TITLE
Update to cgmath 0.14

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,10 +27,8 @@ keywords = ["gamedev", "cgmath", "collision"]
 name = "collision"
 
 [features]
-default = ["rustc-serialize"]
 
 [dependencies]
 num = "0.1"
 approx = "0.1"
-cgmath = "0.12.0"
-rustc-serialize = { version = "0.3", optional = true }
+cgmath = "0.14.0"

--- a/src/aabb.rs
+++ b/src/aabb.rs
@@ -126,7 +126,6 @@ pub trait Aabb<S: BaseNum,
 
 /// A two-dimensional AABB, aka a rectangle.
 #[derive(Copy, Clone, PartialEq)]
-#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
 pub struct Aabb2<S> {
     pub min: Point2<S>,
     pub max: Point2<S>,
@@ -184,7 +183,6 @@ impl<S: BaseNum> fmt::Debug for Aabb2<S> {
 
 /// A three-dimensional AABB, aka a rectangular prism.
 #[derive(Copy, Clone, PartialEq)]
-#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
 pub struct Aabb3<S> {
     pub min: Point3<S>,
     pub max: Point3<S>,

--- a/src/cylinder.rs
+++ b/src/cylinder.rs
@@ -19,7 +19,6 @@ use cgmath::Point3;
 use cgmath::Vector3;
 
 #[derive(Copy, Clone, PartialEq)]
-#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
 pub struct Cylinder<S> {
     pub center: Point3<S>,
     pub axis: Vector3<S>,

--- a/src/frustum.rs
+++ b/src/frustum.rs
@@ -23,7 +23,6 @@ use cgmath::Point3;
 use cgmath::{PerspectiveFov, Ortho, Perspective};
 
 #[derive(Copy, Clone, Debug, PartialEq)]
-#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
 pub struct Frustum<S: BaseFloat> {
     pub left: Plane<S>,
     pub right: Plane<S>,
@@ -96,7 +95,6 @@ impl<S: BaseFloat + 'static> Frustum<S> {
 }
 
 #[derive(Copy, Clone, PartialEq)]
-#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
 pub struct FrustumPoints<S> {
     pub near_top_left: Point3<S>,
     pub near_top_right: Point3<S>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,9 +36,6 @@ extern crate approx;
 extern crate cgmath;
 extern crate num;
 
-#[cfg(feature = "rustc-serialize")]
-extern crate rustc_serialize;
-
 // Re-exports
 pub use aabb::*;
 pub use bound::*;

--- a/src/line.rs
+++ b/src/line.rs
@@ -23,7 +23,6 @@ use cgmath::{VectorSpace, Vector2, Vector3};
 
 /// A generic directed line segment from `origin` to `dest`.
 #[derive(Copy, Clone, PartialEq)]
-#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
 pub struct Line<S, V, P> {
     pub origin: P,
     pub dest: P,

--- a/src/obb.rs
+++ b/src/obb.rs
@@ -19,7 +19,6 @@ use cgmath::{Point2, Point3};
 use cgmath::{Vector2, Vector3};
 
 #[derive(Copy, Clone, PartialEq)]
-#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
 pub struct Obb2<S> {
     pub center: Point2<S>,
     pub axis: Vector2<S>,
@@ -27,7 +26,6 @@ pub struct Obb2<S> {
 }
 
 #[derive(Copy, Clone, PartialEq)]
-#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
 pub struct Obb3<S> {
     pub center: Point3<S>,
     pub axis: Vector3<S>,

--- a/src/plane.rs
+++ b/src/plane.rs
@@ -38,7 +38,6 @@ use cgmath::Zero;
 /// alternative, `A*x + B*y + C*z + D = 0`, because it tends to avoid
 /// superfluous negations (see _Real Time Collision Detection_, p. 55).
 #[derive(Copy, Clone, PartialEq)]
-#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
 pub struct Plane<S> {
     pub n: Vector3<S>,
     pub d: S,

--- a/src/ray.rs
+++ b/src/ray.rs
@@ -21,7 +21,6 @@ use cgmath::{VectorSpace, Vector2, Vector3};
 /// A generic ray starting at `origin` and extending infinitely in
 /// `direction`.
 #[derive(Copy, Clone, PartialEq)]
-#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
 pub struct Ray<S, P, V> {
     pub origin: P,
     pub direction: V,

--- a/src/sphere.rs
+++ b/src/sphere.rs
@@ -23,7 +23,6 @@ use cgmath::{BaseFloat, EuclideanSpace};
 use cgmath::{InnerSpace, Point3};
 
 #[derive(Copy, Clone, PartialEq, Debug)]
-#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
 pub struct Sphere<S: BaseFloat> {
     pub center: Point3<S>,
     pub radius: S,


### PR DESCRIPTION
`rustc-serialize` has been removed. Will be replaced with `serde` ASAP.