### PR TITLE
Adding GJK and EPA algorithm implementations

### DIFF
--- a/src/algorithm/minkowski/epa/epa2d.rs
+++ b/src/algorithm/minkowski/epa/epa2d.rs
@@ -1,0 +1,274 @@
+use std::marker;
+
+use cgmath::{BaseFloat, Point2, Vector2};
+use cgmath::prelude::*;
+use num::NumCast;
+
+use super::*;
+use {CollisionStrategy, Contact};
+use prelude::*;
+use primitive::util::triple_product;
+
+/// EPA algorithm implementation for 2D. Only to be used in [`GJK`](struct.GJK.html).
+#[derive(Debug)]
+pub struct EPA2<S> {
+    m: marker::PhantomData<S>,
+}
+
+impl<S> EPA for EPA2<S>
+where
+    S: BaseFloat,
+{
+    type Point = Point2<S>;
+
+    fn process<SL, SR, TL, TR>(
+        &self,
+        simplex: &mut Vec<SupportPoint<Point2<S>>>,
+        left: &SL,
+        left_transform: &TL,
+        right: &SR,
+        right_transform: &TR,
+    ) -> Option<Contact<Point2<S>>>
+    where
+        SL: SupportFunction<Point = Self::Point>,
+        SR: SupportFunction<Point = Self::Point>,
+        TL: Transform<Self::Point>,
+        TR: Transform<Self::Point>,
+    {
+        let tolerance = NumCast::from(EPA_TOLERANCE).unwrap();
+
+        let mut e = match closest_edge(&simplex) {
+            None => return None,
+            Some(e) => e,
+        };
+
+        for _ in 0..MAX_ITERATIONS {
+            let p = SupportPoint::from_minkowski(
+                left,
+                left_transform,
+                right,
+                right_transform,
+                &e.normal,
+            );
+            let d = p.v.dot(e.normal);
+            if d - e.distance < tolerance {
+                break;
+            } else {
+                simplex.insert(e.index, p);
+            }
+            e = closest_edge(&simplex).unwrap();
+        }
+
+        Some(Contact::new_with_point(
+            CollisionStrategy::FullResolution,
+            e.normal,
+            e.distance,
+            point(&simplex, &e),
+        ))
+    }
+
+    fn new() -> Self {
+        Self {
+            m: marker::PhantomData,
+        }
+    }
+}
+
+/// This function returns the contact point in world space coordinates on shape A.
+///
+/// Compute the closest point to the origin on the given simplex edge, then use that to interpolate
+/// the support points coming from the A shape.
+fn point<S>(simplex: &[SupportPoint<Point2<S>>], edge: &Edge<S>) -> Point2<S>
+where
+    S: BaseFloat,
+{
+    let b = &simplex[edge.index];
+    let a = if edge.index == 0 {
+        &simplex[simplex.len() - 1]
+    } else {
+        &simplex[edge.index - 1]
+    };
+    let oa = -a.v;
+    let ab = b.v - a.v;
+    let t = oa.dot(ab) / ab.magnitude2();
+    if t < S::zero() {
+        a.sup_a.clone()
+    } else if t > S::one() {
+        b.sup_a.clone()
+    } else {
+        a.sup_a + (b.sup_a - a.sup_a) * t
+    }
+}
+
+#[derive(Debug, PartialEq)]
+struct Edge<S> {
+    pub normal: Vector2<S>,
+    pub distance: S,
+    pub index: usize,
+}
+
+impl<S> Edge<S>
+where
+    S: BaseFloat,
+{
+    pub fn new(normal: Vector2<S>, distance: S, index: usize) -> Self {
+        Self {
+            normal,
+            distance,
+            index,
+        }
+    }
+}
+
+fn closest_edge<S>(simplex: &[SupportPoint<Point2<S>>]) -> Option<Edge<S>>
+where
+    S: BaseFloat,
+{
+    if simplex.len() < 3 {
+        None
+    } else {
+        let mut edge = Edge::new(Vector2::zero(), S::infinity(), 0);
+        for i in 0..simplex.len() {
+            let j = if i + 1 == simplex.len() { 0 } else { i + 1 };
+            let a = simplex[i].v;
+            let b = simplex[j].v;
+            let e = b - a;
+            let oa = a;
+            let n = triple_product(&e, &oa, &e).normalize();
+            let d = n.dot(a);
+            if d < edge.distance {
+                edge = Edge::new(n, d, j);
+            }
+        }
+        assert_ulps_ne!(S::infinity(), edge.distance);
+        Some(edge)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use cgmath::{Basis2, Decomposed, Point2, Rad, Rotation2, Vector2};
+
+    use super::*;
+    use algorithm::minkowski::SupportPoint;
+    use primitive::*;
+
+    #[test]
+    fn test_closest_edge_0() {
+        assert_eq!(None, closest_edge::<f32>(&vec![]))
+    }
+
+    #[test]
+    fn test_closest_edge_1() {
+        assert_eq!(None, closest_edge(&vec![sup(10., 10.)]))
+    }
+
+    #[test]
+    fn test_closest_edge_2() {
+        assert_eq!(None, closest_edge(&vec![sup(10., 10.), sup(-10., 5.)]))
+    }
+
+    #[test]
+    fn test_closest_edge_3() {
+        let edge = closest_edge(&vec![sup(10., 10.), sup(-10., 5.), sup(2., -5.)]);
+        assert!(edge.is_some());
+        let edge = edge.unwrap();
+        assert_eq!(2, edge.index);
+        assert_ulps_eq!(2.5607374, edge.distance);
+        assert_ulps_eq!(-0.6401844, edge.normal.x);
+        assert_ulps_eq!(-0.7682213, edge.normal.y);
+    }
+
+    #[test]
+    fn test_epa_0() {
+        let left = Rectangle::new(10., 10.);
+        let left_transform = transform(15., 0., 0.);
+        let right = Rectangle::new(10., 10.);
+        let right_transform = transform(7., 2., 0.);
+        assert!(
+            EPA2::new()
+                .process(
+                    &mut vec![],
+                    &left,
+                    &left_transform,
+                    &right,
+                    &right_transform
+                )
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn test_epa_1() {
+        let left = Rectangle::new(10., 10.);
+        let left_transform = transform(15., 0., 0.);
+        let right = Rectangle::new(10., 10.);
+        let right_transform = transform(7., 2., 0.);
+        let mut simplex = vec![sup(-2., 8.)];
+        assert!(
+            EPA2::new()
+                .process(
+                    &mut simplex,
+                    &left,
+                    &left_transform,
+                    &right,
+                    &right_transform
+                )
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn test_epa_2() {
+        let left = Rectangle::new(10., 10.);
+        let left_transform = transform(15., 0., 0.);
+        let right = Rectangle::new(10., 10.);
+        let right_transform = transform(7., 2., 0.);
+        let mut simplex = vec![sup(-2., 8.), sup(18., -12.)];
+        assert!(
+            EPA2::new()
+                .process(
+                    &mut simplex,
+                    &left,
+                    &left_transform,
+                    &right,
+                    &right_transform
+                )
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn test_epa_3() {
+        let left = Rectangle::new(10., 10.);
+        let left_transform = transform(15., 0., 0.);
+        let right = Rectangle::new(10., 10.);
+        let right_transform = transform(7., 2., 0.);
+        let mut simplex = vec![sup(-2., 8.), sup(18., -12.), sup(-2., -12.)];
+        let contact = EPA2::new().process(
+            &mut simplex,
+            &left,
+            &left_transform,
+            &right,
+            &right_transform,
+        );
+        assert!(contact.is_some());
+        let contact = contact.unwrap();
+        assert_eq!(Vector2::new(-1., 0.), contact.normal);
+        assert_eq!(2., contact.penetration_depth);
+    }
+
+    fn sup(x: f32, y: f32) -> SupportPoint<Point2<f32>> {
+        let mut s = SupportPoint::new();
+        s.v = Vector2::new(x, y);
+        s
+    }
+
+    fn transform(x: f32, y: f32, angle: f32) -> Decomposed<Vector2<f32>, Basis2<f32>> {
+        Decomposed {
+            disp: Vector2::new(x, y),
+            rot: Rotation2::from_angle(Rad(angle)),
+            scale: 1.,
+        }
+    }
+}

--- a/src/algorithm/minkowski/epa/epa3d.rs
+++ b/src/algorithm/minkowski/epa/epa3d.rs
@@ -1,0 +1,358 @@
+use std::marker;
+
+use cgmath::{BaseFloat, Point3, Vector3};
+use cgmath::prelude::*;
+use num::NumCast;
+
+use super::*;
+use super::SupportPoint;
+use {CollisionStrategy, Contact};
+use prelude::*;
+use primitive::util::barycentric_vector;
+
+/// EPA algorithm implementation for 3D. Only to be used in [`GJK`](struct.GJK.html).
+#[derive(Debug)]
+pub struct EPA3<S> {
+    m: marker::PhantomData<S>,
+}
+
+impl<S> EPA for EPA3<S>
+where
+    S: BaseFloat,
+{
+    type Point = Point3<S>;
+
+    fn process<SL, SR, TL, TR>(
+        &self,
+        mut simplex: &mut Vec<SupportPoint<Point3<S>>>,
+        left: &SL,
+        left_transform: &TL,
+        right: &SR,
+        right_transform: &TR,
+    ) -> Option<Contact<Point3<S>>>
+    where
+        SL: SupportFunction<Point = Self::Point>,
+        SR: SupportFunction<Point = Self::Point>,
+        TL: Transform<Self::Point>,
+        TR: Transform<Self::Point>,
+    {
+        if simplex.len() < 4 {
+            return None;
+        }
+        let tolerance = NumCast::from(EPA_TOLERANCE).unwrap();
+        let mut polytope = Polytope::new(&mut simplex);
+        let mut i = 1;
+        loop {
+            let p = {
+                let face = polytope.closest_face_to_origin();
+                let p = SupportPoint::from_minkowski(
+                    left,
+                    left_transform,
+                    right,
+                    right_transform,
+                    &face.normal,
+                );
+                let d = p.v.dot(face.normal);
+                if d - face.distance < tolerance || i >= MAX_ITERATIONS {
+                    return contact(&polytope, face);
+                }
+                p
+            };
+            polytope.add(p);
+            i += 1;
+        }
+    }
+
+    fn new() -> Self {
+        Self {
+            m: marker::PhantomData,
+        }
+    }
+}
+
+#[inline]
+fn contact<S>(polytope: &Polytope<S>, face: &Face<S>) -> Option<Contact<Point3<S>>>
+where
+    S: BaseFloat,
+{
+    Some(Contact::new_with_point(
+        CollisionStrategy::FullResolution,
+        face.normal.clone(), // negate ?
+        face.distance,
+        point(polytope, face),
+    ))
+}
+
+/// This function returns the contact point in world space coordinates on shape A.
+///
+/// Compute the closest point to the origin on the given simplex face, then use that to interpolate
+/// the support points coming from the A shape.
+fn point<S>(polytope: &Polytope<S>, face: &Face<S>) -> Point3<S>
+where
+    S: BaseFloat,
+{
+    let (u, v, w) = barycentric_vector(
+        face.normal * face.distance,
+        polytope.vertices[face.vertices[0]].v,
+        polytope.vertices[face.vertices[1]].v,
+        polytope.vertices[face.vertices[2]].v,
+    );
+
+    polytope.vertices[face.vertices[0]].sup_a * u
+        + polytope.vertices[face.vertices[1]].sup_a.to_vec() * v
+        + polytope.vertices[face.vertices[2]].sup_a.to_vec() * w
+}
+
+#[derive(Debug)]
+struct Polytope<'a, S: 'a>
+where
+    S: BaseFloat,
+{
+    vertices: &'a mut Vec<SupportPoint<Point3<S>>>,
+    faces: Vec<Face<S>>,
+}
+
+impl<'a, S: 'a> Polytope<'a, S>
+where
+    S: BaseFloat,
+{
+    pub fn new(simplex: &'a mut Vec<SupportPoint<Point3<S>>>) -> Self {
+        let faces = Face::new(simplex);
+        Self {
+            vertices: simplex,
+            faces,
+        }
+    }
+
+    pub fn closest_face_to_origin(&'a self) -> &'a Face<S> {
+        let mut face = &self.faces[0];
+        for f in self.faces[1..].iter() {
+            if f.distance < face.distance {
+                face = f;
+            }
+        }
+        face
+    }
+
+    pub fn add(&mut self, sup: SupportPoint<Point3<S>>) {
+        // remove faces that can see the point
+        let mut edges = Vec::default();
+        let mut i = 0;
+        while i < self.faces.len() {
+            let dot = self.faces[i]
+                .normal
+                .dot(sup.v - self.vertices[self.faces[i].vertices[0]].v);
+            if dot > S::zero() {
+                let face = self.faces.swap_remove(i);
+                remove_or_add_edge(&mut edges, (face.vertices[0], face.vertices[1]));
+                remove_or_add_edge(&mut edges, (face.vertices[1], face.vertices[2]));
+                remove_or_add_edge(&mut edges, (face.vertices[2], face.vertices[0]));
+            } else {
+                i += 1;
+            }
+        }
+
+        // add vertex
+        let n = self.vertices.len();
+        self.vertices.push(sup);
+
+        // add new faces
+        let new_faces = edges
+            .into_iter()
+            .map(|(a, b)| Face::new_impl(&self.vertices, n, a, b))
+            .collect::<Vec<_>>();
+        self.faces.extend(new_faces);
+    }
+}
+
+#[derive(Debug)]
+struct Face<S> {
+    pub vertices: [usize; 3],
+    pub normal: Vector3<S>,
+    pub distance: S,
+}
+
+impl<S> Face<S>
+where
+    S: BaseFloat,
+{
+    fn new_impl(simplex: &[SupportPoint<Point3<S>>], a: usize, b: usize, c: usize) -> Self {
+        let ab = simplex[b].v - simplex[a].v;
+        let ac = simplex[c].v - simplex[a].v;
+        let normal = ab.cross(ac).normalize();
+        let distance = normal.dot(simplex[a].v);
+        Self {
+            vertices: [a, b, c],
+            normal,
+            distance,
+        }
+    }
+
+    pub fn new(simplex: &[SupportPoint<Point3<S>>]) -> Vec<Self> {
+        vec![
+            Self::new_impl(simplex, 3, 2, 1), // ABC
+            Self::new_impl(simplex, 3, 1, 0), // ACD
+            Self::new_impl(simplex, 3, 0, 2), // ADB
+            Self::new_impl(simplex, 2, 0, 1), // BDC
+        ]
+    }
+}
+
+#[inline]
+fn remove_or_add_edge(edges: &mut Vec<(usize, usize)>, edge: (usize, usize)) {
+    match edges.iter().position(|e| edge.0 == e.1 && edge.1 == e.0) {
+        Some(i) => {
+            edges.remove(i);
+        }
+        None => edges.push(edge),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use cgmath::{Decomposed, Quaternion, Rad, Vector3};
+
+    use super::*;
+    use primitive::*;
+
+    #[test]
+    fn test_remove_or_add_edge_added() {
+        let mut edges = vec![(1, 2), (6, 5)];
+        remove_or_add_edge(&mut edges, (4, 3));
+        assert_eq!(3, edges.len());
+        assert_eq!((4, 3), edges[2]);
+    }
+
+    #[test]
+    fn test_remove_or_add_edge_removed() {
+        let mut edges = vec![(1, 2), (6, 5)];
+        remove_or_add_edge(&mut edges, (2, 1));
+        assert_eq!(1, edges.len());
+        assert_eq!((6, 5), edges[0]);
+    }
+
+    #[test]
+    fn test_face_impl() {
+        let simplex = vec![
+            sup(3., -3., -1.),
+            sup(-3., -3., -1.),
+            sup(0., 3., -1.),
+            sup(0., 0., 5.),
+        ];
+        let faces = Face::new(&simplex);
+        assert_eq!(4, faces.len());
+        assert_face(
+            &faces[0],
+            3,
+            2,
+            1,
+            -0.8728715,
+            0.43643576,
+            0.21821788,
+            1.0910894,
+        );
+        assert_face(&faces[1], 3, 1, 0, 0., -0.89442724, 0.44721362, 2.236068);
+        assert_face(
+            &faces[2],
+            3,
+            0,
+            2,
+            0.8728715,
+            0.43643576,
+            0.21821788,
+            1.0910894,
+        );
+        assert_face(&faces[3], 2, 0, 1, 0., 0., -1., 1.0);
+    }
+
+    #[test]
+    fn test_polytope_closest_to_origin() {
+        let mut simplex = vec![
+            sup(3., -3., -1.),
+            sup(-3., -3., -1.),
+            sup(0., 3., -1.),
+            sup(0., 0., 5.),
+        ];
+        let polytope = Polytope::new(&mut simplex);
+        let face = polytope.closest_face_to_origin();
+        assert_face(face, 2, 0, 1, 0., 0., -1., 1.0);
+    }
+
+    #[test]
+    fn test_polytope_add() {
+        let mut simplex = vec![
+            sup(3., -3., -1.),
+            sup(-3., -3., -1.),
+            sup(0., 3., -1.),
+            sup(0., 0., 5.),
+        ];
+        let mut polytope = Polytope::new(&mut simplex);
+        polytope.add(sup(0., 0., -2.));
+        assert_eq!(5, polytope.vertices.len());
+        assert_eq!(6, polytope.faces.len());
+        assert_eq!([4, 2, 0], polytope.faces[3].vertices);
+        assert_eq!([4, 0, 1], polytope.faces[4].vertices);
+        assert_eq!([4, 1, 2], polytope.faces[5].vertices);
+    }
+
+    #[test]
+    fn test_epa_3d() {
+        let left = Cuboid::new(10., 10., 10.);
+        let left_transform = transform_3d(15., 0., 0., 0.);
+        let right = Cuboid::new(10., 10., 10.);
+        let right_transform = transform_3d(7., 2., 0., 0.);
+        let mut simplex = vec![
+            sup(18., -12., 0.),
+            sup(-2., 8., 0.),
+            sup(-2., -12., 0.),
+            sup(8., -2., -10.),
+        ];
+        let contact = EPA3::new().process(
+            &mut simplex,
+            &left,
+            &left_transform,
+            &right,
+            &right_transform,
+        );
+        assert!(contact.is_some());
+        let contact = contact.unwrap();
+        assert_eq!(Vector3::new(-1., 0., 0.), contact.normal);
+        assert_eq!(2., contact.penetration_depth);
+    }
+
+    fn assert_face(
+        face: &Face<f32>,
+        a: usize,
+        b: usize,
+        c: usize,
+        nx: f32,
+        ny: f32,
+        nz: f32,
+        d: f32,
+    ) {
+        assert_eq!([a, b, c], face.vertices);
+        assert_ulps_eq!(nx, face.normal.x);
+        assert_ulps_eq!(ny, face.normal.y);
+        assert_ulps_eq!(nz, face.normal.z);
+        assert_ulps_eq!(d, face.distance);
+    }
+
+    fn sup(x: f32, y: f32, z: f32) -> SupportPoint<Point3<f32>> {
+        let mut s = SupportPoint::new();
+        s.v = Vector3::new(x, y, z);
+        s
+    }
+
+    fn transform_3d(
+        x: f32,
+        y: f32,
+        z: f32,
+        angle_z: f32,
+    ) -> Decomposed<Vector3<f32>, Quaternion<f32>> {
+        Decomposed {
+            disp: Vector3::new(x, y, z),
+            rot: Quaternion::from_angle_z(Rad(angle_z)),
+            scale: 1.,
+        }
+    }
+}

--- a/src/algorithm/minkowski/epa/mod.rs
+++ b/src/algorithm/minkowski/epa/mod.rs
@@ -1,0 +1,43 @@
+//! Expanding Polytope Algorithm
+
+pub use self::epa2d::EPA2;
+pub use self::epa3d::EPA3;
+
+mod epa2d;
+mod epa3d;
+
+use cgmath::prelude::*;
+
+use super::SupportPoint;
+use Contact;
+use prelude::*;
+
+pub const EPA_TOLERANCE: f32 = 0.00001;
+pub const MAX_ITERATIONS: u32 = 100;
+
+/// Expanding Polytope Algorithm base trait
+pub trait EPA {
+    /// Point type
+    type Point: EuclideanSpace;
+
+    /// Process the given simplex, and compute the contact point.
+    ///
+    /// The given simplex must be a complete simplex for the given space, and it must enclose the
+    /// origin.
+    fn process<SL, SR, TL, TR>(
+        &self,
+        simplex: &mut Vec<SupportPoint<Self::Point>>,
+        left: &SL,
+        left_transform: &TL,
+        right: &SR,
+        right_transform: &TR,
+    ) -> Option<Contact<Self::Point>>
+    where
+        SL: SupportFunction<Point = Self::Point>,
+        SR: SupportFunction<Point = Self::Point>,
+        TL: Transform<Self::Point>,
+        TR: Transform<Self::Point>;
+
+    /// Create a new EPA instance
+    fn new() -> Self;
+}

--- a/src/algorithm/minkowski/gjk/mod.rs
+++ b/src/algorithm/minkowski/gjk/mod.rs
@@ -1,0 +1,383 @@
+//! GJK distance/collision detection algorithm. For now only have implementation of collision
+//! detection, not distance computation.
+
+pub use self::simplex::SimplexProcessor;
+
+use std::ops::Neg;
+
+use cgmath::BaseFloat;
+use cgmath::prelude::*;
+
+use self::simplex::{SimplexProcessor2, SimplexProcessor3};
+use {CollisionStrategy, Contact};
+use algorithm::minkowski::{EPA2, EPA3, SupportPoint, EPA};
+use prelude::*;
+
+mod simplex;
+
+const MAX_ITERATIONS: u32 = 100;
+
+/// GJK algorithm for 2D, see [GJK](struct.GJK.html) for more information.
+pub type GJK2<S> = GJK<SimplexProcessor2<S>, EPA2<S>>;
+
+/// GJK algorithm for 3D, see [GJK](struct.GJK.html) for more information.
+pub type GJK3<S> = GJK<SimplexProcessor3<S>, EPA3<S>>;
+
+/// Gilbert-Johnson-Keerthi narrow phase collision detection algorithm.
+///
+/// # Type parameters:
+///
+/// - `S`: simplex processor type. Should be either
+///        [`SimplexProcessor2`](struct.SimplexProcessor2.html) or
+///        [`SimplexProcessor3`](struct.SimplexProcessor3.html)
+/// - `E`: EPA algorithm implementation type. Should be either
+///        [`EPA2`](struct.EPA2.html) or
+///        [`EPA3`](struct.EPA3.html)
+///
+#[derive(Debug)]
+pub struct GJK<SP, E> {
+    simplex_processor: SP,
+    epa: E,
+}
+
+impl<SP, E> GJK<SP, E>
+where
+    SP: SimplexProcessor,
+    <SP::Point as EuclideanSpace>::Scalar: BaseFloat,
+    E: EPA<Point = SP::Point>,
+{
+    /// Create a new GJK algorithm implementation
+    pub fn new() -> Self {
+        Self {
+            simplex_processor: SP::new(),
+            epa: E::new(),
+        }
+    }
+
+    /// Do intersection test on the given primitives
+    ///
+    /// ## Parameters:
+    ///
+    /// - `left`: left primitive
+    /// - `left_transform`: model-to-world-transform for the left primitive
+    /// - `right`: right primitive,
+    /// - `right_transform`: model-to-world-transform for the right primitive
+    ///
+    /// ## Returns:
+    ///
+    /// Will return a simplex if a collision was detected. For 2D, the simplex will be a triangle,
+    /// for 3D, it will be a tetrahedron. The simplex will enclose the origin.
+    /// If no collision was detected, None is returned.
+    ///
+    pub fn intersect<P, PL, PR, TL, TR>(
+        &self,
+        left: &PL,
+        left_transform: &TL,
+        right: &PR,
+        right_transform: &TR,
+    ) -> Option<Vec<SupportPoint<P>>>
+    where
+        P: EuclideanSpace,
+        P::Scalar: BaseFloat,
+        PL: SupportFunction<Point = P>,
+        PR: SupportFunction<Point = P>,
+        SP: SimplexProcessor<Point = P>,
+        P::Diff: Neg<Output = P::Diff> + InnerSpace,
+        TL: Transform<P>,
+        TR: Transform<P>,
+    {
+        let right_pos = right_transform.transform_point(P::origin());
+        let left_pos = left_transform.transform_point(P::origin());
+        let mut d = right_pos - left_pos;
+        let a = SupportPoint::from_minkowski(left, left_transform, right, right_transform, &d);
+        if a.v.dot(d) <= P::Scalar::zero() {
+            return None;
+        }
+        let mut simplex: Vec<SupportPoint<P>> = Vec::default();
+        simplex.push(a);
+        d = d.neg();
+        let mut i = 0;
+        loop {
+            let a = SupportPoint::from_minkowski(left, left_transform, right, right_transform, &d);
+            if a.v.dot(d) <= P::Scalar::zero() {
+                return None;
+            } else {
+                simplex.push(a);
+                if self.simplex_processor.check_origin(&mut simplex, &mut d) {
+                    return Some(simplex);
+                }
+            }
+            i += 1;
+            if i >= MAX_ITERATIONS {
+                return None;
+            }
+        }
+    }
+
+    /// Given a GJK simplex that encloses the origin, compute the contact manifold.
+    ///
+    /// Uses the EPA algorithm to find the contact information from the simplex.
+    pub fn get_contact_manifold<P, PL, PR, TL, TR>(
+        &self,
+        mut simplex: &mut Vec<SupportPoint<P>>,
+        left: &PL,
+        left_transform: &TL,
+        right: &PR,
+        right_transform: &TR,
+    ) -> Option<Contact<P>>
+    where
+        P: EuclideanSpace,
+        PL: SupportFunction<Point = P>,
+        PR: SupportFunction<Point = P>,
+        TL: Transform<P>,
+        TR: Transform<P>,
+        SP: SimplexProcessor<Point = P>,
+    {
+        self.epa
+            .process(&mut simplex, left, left_transform, right, right_transform)
+    }
+
+    /// Do intersection testing on the given primitives, and return the contact manifold.
+    ///
+    /// ## Parameters:
+    ///
+    /// - `strategy`: strategy to use, if `CollisionOnly` it will only return a boolean result,
+    ///               otherwise, EPA will be used to compute the exact contact point.
+    /// - `left`: left primitive
+    /// - `left_transform`: model-to-world-transform for the left primitive
+    /// - `right`: right primitive,
+    /// - `right_transform`: model-to-world-transform for the right primitive
+    ///
+    /// ## Returns:
+    ///
+    /// Will optionally return a `Contact` if a collision was detected. In `CollisionOnly` mode,
+    /// this contact will only be a boolean result. For `FullResolution` mode, the contact will
+    /// contain a full manifold (collision normal, penetration depth and contact point).
+    pub fn intersection<P, PL, PR, TL, TR>(
+        &self,
+        strategy: &CollisionStrategy,
+        left: &PL,
+        left_transform: &TL,
+        right: &PR,
+        right_transform: &TR,
+    ) -> Option<Contact<P>>
+    where
+        P: EuclideanSpace,
+        P::Scalar: BaseFloat,
+        P::Diff: Neg<Output = P::Diff> + InnerSpace,
+        PL: SupportFunction<Point = P>,
+        PR: SupportFunction<Point = P>,
+        TL: Transform<P>,
+        TR: Transform<P>,
+        SP: SimplexProcessor<Point = P>,
+    {
+        match self.intersect(left, left_transform, right, right_transform) {
+            None => None,
+            Some(mut simplex) => {
+                match *strategy {
+                    CollisionStrategy::CollisionOnly => {
+                        Some(Contact::new(CollisionStrategy::CollisionOnly))
+                    }
+                    CollisionStrategy::FullResolution => {
+                        self.get_contact_manifold(
+                            &mut simplex,
+                            left,
+                            left_transform,
+                            right,
+                            right_transform,
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    /// Do intersection test on the given complex shapes, and return the actual intersection point
+    ///
+    /// ## Parameters:
+    ///
+    /// - `strategy`: strategy to use, if `CollisionOnly` it will only return a boolean result,
+    ///               otherwise, EPA will be used to compute the exact contact point.
+    /// - `left`: shape consisting of a slice of primitive + local-to-model-transform for each
+    ///           primitive,
+    /// - `left_transform`: model-to-world-transform for the left shape
+    /// - `right`: shape consisting of a slice of primitive + local-to-model-transform for each
+    ///           primitive,
+    /// - `right_transform`: model-to-world-transform for the right shape
+    ///
+    /// ## Returns:
+    ///
+    /// Will optionally return a `Contact` if a collision was detected. In `CollisionOnly` mode,
+    /// this contact will only be a boolean result. For `FullResolution` mode, the contact will
+    /// contain a full manifold (collision normal, penetration depth and contact point), for the
+    /// contact with the highest penetration depth.
+    pub fn intersection_complex<P, PL, PR, TL, TR>(
+        &self,
+        strategy: &CollisionStrategy,
+        left: &[(PL, TL)],
+        left_transform: &TL,
+        right: &[(PR, TR)],
+        right_transform: &TR,
+    ) -> Option<Contact<P>>
+    where
+        P: EuclideanSpace,
+        P::Scalar: BaseFloat,
+        P::Diff: Neg<Output = P::Diff> + InnerSpace,
+        PL: SupportFunction<Point = P>,
+        PR: SupportFunction<Point = P>,
+        TL: Transform<P>,
+        TR: Transform<P>,
+        SP: SimplexProcessor<Point = P>,
+    {
+        let mut contacts = Vec::default();
+        for &(ref left_primitive, ref left_local_transform) in left.iter() {
+            let left_transform = left_transform.concat(left_local_transform);
+            for &(ref right_primitive, ref right_local_transform) in right.iter() {
+                let right_transform = right_transform.concat(right_local_transform);
+                match self.intersect(
+                    left_primitive,
+                    &left_transform,
+                    right_primitive,
+                    &right_transform,
+                ) {
+                    None => (),
+                    Some(mut simplex) => {
+                        match *strategy {
+                            CollisionStrategy::CollisionOnly => {
+                                return Some(Contact::new(CollisionStrategy::CollisionOnly));
+                            }
+                            CollisionStrategy::FullResolution => {
+                                match self.get_contact_manifold(
+                                    &mut simplex,
+                                    left_primitive,
+                                    &left_transform,
+                                    right_primitive,
+                                    &right_transform,
+                                ) {
+                                    Some(contact) => contacts.push(contact),
+                                    None => (),
+                                };
+                            }
+                        }
+                    }
+                };
+            }
+        }
+
+        // CollisionOnly handling will have returned already if there was a contact, so this
+        // scenario will only happen when we have a contact in FullResolution mode
+        if contacts.len() > 0 {
+            // penetration depth defaults to 0., and can't be nan from EPA,
+            // so unwrapping is safe
+            contacts
+                .iter()
+                .max_by(|l, r| {
+                    l.penetration_depth
+                        .partial_cmp(&r.penetration_depth)
+                        .unwrap()
+                })
+                .cloned()
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use cgmath::{Basis2, Decomposed, Point2, Point3, Quaternion, Rad, Rotation2, Rotation3,
+                 Vector2, Vector3};
+
+    use super::*;
+    use primitive::*;
+
+    fn transform(x: f32, y: f32, angle: f32) -> Decomposed<Vector2<f32>, Basis2<f32>> {
+        Decomposed {
+            disp: Vector2::new(x, y),
+            rot: Rotation2::from_angle(Rad(angle)),
+            scale: 1.,
+        }
+    }
+
+    fn transform_3d(
+        x: f32,
+        y: f32,
+        z: f32,
+        angle_z: f32,
+    ) -> Decomposed<Vector3<f32>, Quaternion<f32>> {
+        Decomposed {
+            disp: Vector3::new(x, y, z),
+            rot: Quaternion::from_angle_z(Rad(angle_z)),
+            scale: 1.,
+        }
+    }
+
+    #[test]
+    fn test_gjk_miss() {
+        let left = Rectangle::new(10., 10.);
+        let left_transform = transform(15., 0., 0.);
+        let right = Rectangle::new(10., 10.);
+        let right_transform = transform(-15., 0., 0.);
+        let gjk = GJK2::new();
+        assert!(
+            gjk.intersect(&left, &left_transform, &right, &right_transform)
+                .is_none()
+        );
+        assert!(
+            gjk.intersection(
+                &CollisionStrategy::FullResolution,
+                &left,
+                &left_transform,
+                &right,
+                &right_transform
+            ).is_none()
+        )
+    }
+
+    #[test]
+    fn test_gjk_hit() {
+        let left = Rectangle::new(10., 10.);
+        let left_transform = transform(15., 0., 0.);
+        let right = Rectangle::new(10., 10.);
+        let right_transform = transform(7., 2., 0.);
+        let gjk = GJK2::new();
+        let simplex = gjk.intersect(&left, &left_transform, &right, &right_transform);
+        assert!(simplex.is_some());
+        let contact = gjk.intersection(
+            &CollisionStrategy::FullResolution,
+            &left,
+            &left_transform,
+            &right,
+            &right_transform,
+        );
+        assert!(contact.is_some());
+        let contact = contact.unwrap();
+        assert_eq!(Vector2::new(-1., 0.), contact.normal);
+        assert_eq!(2., contact.penetration_depth);
+        assert_eq!(Point2::new(10., 1.), contact.contact_point);
+    }
+
+    #[test]
+    fn test_gjk_3d_hit() {
+        let left = Cuboid::new(10., 10., 10.);
+        let left_transform = transform_3d(15., 0., 0., 0.);
+        let right = Cuboid::new(10., 10., 10.);
+        let right_transform = transform_3d(7., 2., 0., 0.);
+        let gjk = GJK3::new();
+        let simplex = gjk.intersect(&left, &left_transform, &right, &right_transform);
+        assert!(simplex.is_some());
+        let contact = gjk.intersection(
+            &CollisionStrategy::FullResolution,
+            &left,
+            &left_transform,
+            &right,
+            &right_transform,
+        );
+        assert!(contact.is_some());
+        let contact = contact.unwrap();
+        println!("{:?}", contact);
+        assert_eq!(Vector3::new(-1., 0., 0.), contact.normal);
+        assert_eq!(2., contact.penetration_depth);
+        assert_ulps_eq!(Point3::new(10., 1., 5.), contact.contact_point);
+    }
+}

--- a/src/algorithm/minkowski/gjk/simplex/mod.rs
+++ b/src/algorithm/minkowski/gjk/simplex/mod.rs
@@ -1,0 +1,26 @@
+pub use self::simplex2d::SimplexProcessor2;
+pub use self::simplex3d::SimplexProcessor3;
+
+mod simplex2d;
+mod simplex3d;
+
+use cgmath::prelude::*;
+
+use algorithm::minkowski::SupportPoint;
+
+/// Defined a simplex processor for use in GJK.
+pub trait SimplexProcessor {
+    /// The point type of the processor
+    type Point: EuclideanSpace;
+
+    /// Check if the given simplex contains origin, and if not, update the simplex and search
+    /// direction
+    fn check_origin(
+        &self,
+        simplex: &mut Vec<SupportPoint<Self::Point>>,
+        d: &mut <Self::Point as EuclideanSpace>::Diff,
+    ) -> bool;
+
+    /// Create a new simplex processor
+    fn new() -> Self;
+}

--- a/src/algorithm/minkowski/gjk/simplex/simplex2d.rs
+++ b/src/algorithm/minkowski/gjk/simplex/simplex2d.rs
@@ -1,0 +1,144 @@
+use std::marker;
+use std::ops::Neg;
+
+use cgmath::{BaseFloat, Point2, Vector2};
+use cgmath::prelude::*;
+
+use super::SimplexProcessor;
+use algorithm::minkowski::SupportPoint;
+use primitive::util::triple_product;
+
+/// Simplex processor implementation for 2D. Only to be used in [`GJK`](struct.GJK.html).
+#[derive(Debug)]
+pub struct SimplexProcessor2<S> {
+    m: marker::PhantomData<S>,
+}
+
+impl<S> SimplexProcessor for SimplexProcessor2<S>
+where
+    S: BaseFloat,
+{
+    type Point = Point2<S>;
+
+    fn check_origin(&self, simplex: &mut Vec<SupportPoint<Point2<S>>>, d: &mut Vector2<S>) -> bool {
+        // 3 points
+        if simplex.len() == 3 {
+            let a = simplex[2].v;
+            let b = simplex[1].v;
+            let c = simplex[0].v;
+
+            let ao = a.neg();
+            let ab = b - a;
+            let ac = c - a;
+
+            let abp = triple_product(&ac, &ab, &ab);
+            if abp.dot(ao) > S::zero() {
+                simplex.remove(0);
+                *d = abp;
+            } else {
+                let acp = triple_product(&ab, &ac, &ac);
+                if acp.dot(ao) > S::zero() {
+                    simplex.remove(1);
+                    *d = acp;
+                } else {
+                    return true;
+                }
+            }
+        }
+        // 2 points
+        else if simplex.len() == 2 {
+            let a = simplex[1].v;
+            let b = simplex[0].v;
+
+            let ao = a.neg();
+            let ab = b - a;
+
+            *d = triple_product(&ab, &ao, &ab);
+        }
+        // 0-1 point means we can't really do anything
+        false
+    }
+
+    fn new() -> Self {
+        Self {
+            m: marker::PhantomData,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use cgmath::Vector2;
+
+    use super::*;
+    use algorithm::minkowski::SupportPoint;
+
+    #[test]
+    fn test_check_origin_empty() {
+        let processor = SimplexProcessor2::new();
+        let mut direction = Vector2::new(1., 0.);
+        let mut simplex = vec![];
+        assert!(!processor.check_origin(&mut simplex, &mut direction));
+        assert_eq!(0, simplex.len());
+        assert_eq!(Vector2::new(1., 0.), direction);
+    }
+
+    #[test]
+    fn test_check_origin_single() {
+        let processor = SimplexProcessor2::new();
+        let mut direction = Vector2::new(1., 0.);
+        let mut simplex = vec![sup(40., 0.)];
+        assert!(!processor.check_origin(&mut simplex, &mut direction));
+        assert_eq!(1, simplex.len());
+        assert_eq!(Vector2::new(1., 0.), direction);
+    }
+
+    #[test]
+    fn test_check_origin_edge() {
+        let processor = SimplexProcessor2::new();
+        let mut direction = Vector2::new(1., 0.);
+        let mut simplex = vec![sup(40., 10.), sup(-10., 10.)];
+        assert!(!processor.check_origin(&mut simplex, &mut direction));
+        assert_eq!(2, simplex.len());
+        assert_eq!(0., direction.x);
+        assert!(direction.y < 0.);
+    }
+
+    #[test]
+    fn test_check_origin_triangle_outside_ac() {
+        let processor = SimplexProcessor2::new();
+        let mut direction = Vector2::new(1., 0.);
+        let mut simplex = vec![sup(40., 10.), sup(-10., 10.), sup(0., 3.)];
+        assert!(!processor.check_origin(&mut simplex, &mut direction));
+        assert_eq!(2, simplex.len());
+        assert!(direction.x < 0.);
+        assert!(direction.y < 0.);
+    }
+
+    #[test]
+    fn test_check_origin_triangle_outside_ab() {
+        let processor = SimplexProcessor2::new();
+        let mut direction = Vector2::new(1., 0.);
+        let mut simplex = vec![sup(40., 10.), sup(10., 10.), sup(3., -3.)];
+        assert!(!processor.check_origin(&mut simplex, &mut direction));
+        assert_eq!(2, simplex.len());
+        assert!(direction.x < 0.);
+        assert!(direction.y > 0.);
+    }
+
+    #[test]
+    fn test_check_origin_triangle_hit() {
+        let processor = SimplexProcessor2::new();
+        let mut direction = Vector2::new(1., 0.);
+        let mut simplex = vec![sup(40., 10.), sup(-10., 10.), sup(0., -3.)];
+        assert!(processor.check_origin(&mut simplex, &mut direction));
+        assert_eq!(3, simplex.len());
+        assert_eq!(Vector2::new(1., 0.), direction);
+    }
+
+    fn sup(x: f32, y: f32) -> SupportPoint<Point2<f32>> {
+        let mut s = SupportPoint::new();
+        s.v = Vector2::new(x, y);
+        s
+    }
+}

--- a/src/algorithm/minkowski/gjk/simplex/simplex3d.rs
+++ b/src/algorithm/minkowski/gjk/simplex/simplex3d.rs
@@ -1,0 +1,327 @@
+use std::marker;
+use std::ops::Neg;
+
+use cgmath::{BaseFloat, Point3, Vector3};
+use cgmath::prelude::*;
+
+use super::SimplexProcessor;
+use algorithm::minkowski::SupportPoint;
+
+/// Simplex processor implementation for 3D. Only to be used in [`GJK`](struct.GJK.html).
+#[derive(Debug)]
+pub struct SimplexProcessor3<S> {
+    m: marker::PhantomData<S>,
+}
+
+impl<S> SimplexProcessor for SimplexProcessor3<S>
+where
+    S: BaseFloat,
+{
+    type Point = Point3<S>;
+
+    fn check_origin(&self, simplex: &mut Vec<SupportPoint<Point3<S>>>, v: &mut Vector3<S>) -> bool {
+        // 4 points, full tetrahedron, origin could be inside
+        if simplex.len() == 4 {
+            let a = simplex[3].v;
+            let b = simplex[2].v;
+            let c = simplex[1].v;
+            let d = simplex[0].v;
+
+            let ao = a.neg();
+            let ab = b - a;
+            let ac = c - a;
+
+            let abc = ab.cross(ac);
+
+            // origin outside plane ABC, remove D and check side
+            // need to check both edges
+            if abc.dot(ao) > S::zero() {
+                simplex.remove(0);
+                check_side(&abc, &ab, &ac, &ao, simplex, v, true, false);
+            } else {
+                let ad = d - a;
+                let acd = ac.cross(ad);
+                // origin outside plane ACD, remove B and check side
+                // no need to test first edge, since that region is also over ABC
+                if acd.dot(ao) > S::zero() {
+                    simplex.remove(2);
+                    check_side(&acd, &ac, &ad, &ao, simplex, v, true, true);
+                } else {
+                    let adb = ad.cross(ab);
+                    // origin outside plane ADB, remove C and check side
+                    // no need to test edges, since those regions are covered in earlier tests
+                    if adb.dot(ao) > S::zero() {
+                        // [b, d, a]
+                        simplex.remove(1);
+                        simplex.swap(0, 1);
+                        *v = adb;
+                    // origin is inside simplex
+                    } else {
+                        return true;
+                    }
+                }
+            }
+        }
+        // 3 points, can't do origin check, find closest feature to origin, and move that way
+        else if simplex.len() == 3 {
+            let a = simplex[2].v;
+            let b = simplex[1].v;
+            let c = simplex[0].v;
+
+            let ao = a.neg();
+            let ab = b - a;
+            let ac = c - a;
+
+            check_side(&ab.cross(ac), &ab, &ac, &ao, simplex, v, false, false);
+        }
+        // 2 points, can't do much with only an edge, only find a new search direction
+        else if simplex.len() == 2 {
+            let a = simplex[1].v;
+            let b = simplex[0].v;
+
+            let ao = a.neg();
+            let ab = b - a;
+
+            *v = cross_aba(&ab, &ao);
+        }
+        // 0-1 points
+        false
+    }
+
+    fn new() -> Self {
+        Self {
+            m: marker::PhantomData,
+        }
+    }
+}
+
+#[inline]
+fn cross_aba<S>(a: &Vector3<S>, b: &Vector3<S>) -> Vector3<S>
+where
+    S: BaseFloat,
+{
+    a.cross(*b).cross(*a)
+}
+
+#[inline]
+fn check_side<S>(
+    abc: &Vector3<S>,
+    ab: &Vector3<S>,
+    ac: &Vector3<S>,
+    ao: &Vector3<S>,
+    simplex: &mut Vec<SupportPoint<Point3<S>>>,
+    v: &mut Vector3<S>,
+    above: bool,
+    ignore_ab: bool,
+) where
+    S: BaseFloat,
+{
+    let ab_perp = ab.cross(*abc);
+
+    // origin outside AB, remove C and v = edge normal towards origin
+    if !ignore_ab && ab_perp.dot(*ao) > S::zero() {
+        simplex.remove(0);
+        *v = cross_aba(ab, ao);
+        return;
+    }
+
+    let ac_perp = abc.cross(*ac);
+
+    // origin outside AC, remove B and v = edge normal towards origin
+    if ac_perp.dot(*ao) > S::zero() {
+        simplex.remove(1);
+        *v = cross_aba(ac, ao);
+        return;
+        // origin above triangle, set v = surface normal towards origin
+    }
+
+    if above {
+        *v = *abc;
+    } else if abc.dot(*ao) > S::zero() {
+        // [c, b, a]
+        *v = *abc;
+    // origin below triangle, rewind simplex and set v = surface normal towards origin
+    } else {
+        // [b, c, a]
+        simplex.swap(0, 1);
+        *v = abc.neg();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ops::Neg;
+
+    use cgmath::{Point3, Vector3};
+
+    use super::*;
+    use algorithm::minkowski::SupportPoint;
+
+    #[test]
+    fn test_check_side_outside_ab() {
+        let mut simplex = vec![sup(8., -10., 0.), sup(-1., -10., 0.), sup(3., 5., 0.)];
+        let v = test_check_side(&mut simplex, false, false);
+        assert_eq!(2, simplex.len());
+        assert_eq!(Vector3::new(-1., -10., 0.), simplex[0].v); // B should be last in the simplex
+        assert_ulps_eq!(-375., v.x);
+        assert_ulps_eq!(100., v.y);
+        assert_ulps_eq!(0., v.z);
+    }
+
+    #[test]
+    fn test_check_side_outside_ac() {
+        let mut simplex = vec![sup(2., -10., 0.), sup(-7., -10., 0.), sup(-3., 5., 0.)];
+        let v = test_check_side(&mut simplex, false, false);
+        assert_eq!(2, simplex.len());
+        assert_eq!(Vector3::new(2., -10., 0.), simplex[0].v); // C should be last in the simplex
+        assert_ulps_eq!(300., v.x);
+        assert_ulps_eq!(100., v.y);
+        assert_ulps_eq!(0., v.z);
+    }
+
+    #[test]
+    fn test_check_side_above() {
+        let mut simplex = vec![sup(5., -10., -1.), sup(-4., -10., -1.), sup(0., 5., -1.)];
+        let v = test_check_side(&mut simplex, false, false);
+        assert_eq!(3, simplex.len());
+        assert_eq!(Vector3::new(5., -10., -1.), simplex[0].v); // C should be last in the simplex
+        assert_ulps_eq!(0., v.x);
+        assert_ulps_eq!(0., v.y);
+        assert_ulps_eq!(135., v.z);
+    }
+
+    #[test]
+    fn test_check_side_below() {
+        let mut simplex = vec![sup(5., -10., 1.), sup(-4., -10., 1.), sup(0., 5., 1.)];
+        let v = test_check_side(&mut simplex, false, false);
+        assert_eq!(3, simplex.len());
+        assert_eq!(Vector3::new(-4., -10., 1.), simplex[0].v); // B should be last in the simplex
+        assert_ulps_eq!(0., v.x);
+        assert_ulps_eq!(0., v.y);
+        assert_ulps_eq!(-135., v.z);
+    }
+
+    #[test]
+    fn test_check_origin_empty() {
+        let mut simplex = vec![];
+        let (hit, v) = test_check_origin(&mut simplex);
+        assert!(!hit);
+        assert!(simplex.is_empty());
+        assert_eq!(Vector3::zero(), v);
+    }
+
+    #[test]
+    fn test_check_origin_point() {
+        let mut simplex = vec![sup(8., -10., 0.)];
+        let (hit, v) = test_check_origin(&mut simplex);
+        assert!(!hit);
+        assert_eq!(1, simplex.len());
+        assert_eq!(Vector3::zero(), v);
+    }
+
+    #[test]
+    fn test_check_origin_line() {
+        let mut simplex = vec![sup(8., -10., 0.), sup(-1., -10., 0.)];
+        let (hit, v) = test_check_origin(&mut simplex);
+        assert!(!hit);
+        assert_eq!(2, simplex.len());
+        assert_eq!(Vector3::new(0., 810., 0.), v);
+    }
+
+    #[test]
+    fn test_check_origin_triangle() {
+        let mut simplex = vec![sup(5., -10., -1.), sup(-4., -10., -1.), sup(0., 5., -1.)];
+        let (hit, v) = test_check_origin(&mut simplex);
+        assert!(!hit);
+        assert_eq!(3, simplex.len());
+        assert_eq!(Vector3::new(0., 0., 135.), v);
+    }
+
+    #[test]
+    fn test_check_origin_tetrahedron_outside_abc() {
+        let mut simplex = vec![
+            sup(8., -10., -1.),
+            sup(-1., -10., -1.),
+            sup(3., 5., -1.),
+            sup(3., -3., 5.),
+        ];
+        let (hit, v) = test_check_origin(&mut simplex);
+        assert!(!hit);
+        assert_eq!(3, simplex.len());
+        assert_eq!(Vector3::new(-1., -10., -1.), simplex[0].v);
+        assert_eq!(Vector3::new(-90., 24., 32.), v);
+    }
+
+    #[test]
+    fn test_check_origin_tetrahedron_outside_acd() {
+        let mut simplex = vec![
+            sup(8., 0.1, -1.),
+            sup(-1., 0.1, -1.),
+            sup(3., 15., -1.),
+            sup(3., 7., 5.),
+        ];
+        let (hit, v) = test_check_origin(&mut simplex);
+        assert!(!hit);
+        assert_eq!(3, simplex.len());
+        assert_eq!(Vector3::new(3., 7., 5.), simplex[2].v);
+        assert_eq!(Vector3::new(-1., 0.1, -1.), simplex[1].v);
+        assert_eq!(Vector3::new(8., 0.1, -1.), simplex[0].v);
+        assert_eq!(Vector3::new(0., -54., 62.1), v);
+    }
+
+    #[test]
+    fn test_check_origin_tetrahedron_outside_adb() {
+        let mut simplex = vec![
+            sup(2., -10., -1.),
+            sup(-7., -10., -1.),
+            sup(-3., 5., -1.),
+            sup(-3., -3., 5.),
+        ];
+        let (hit, v) = test_check_origin(&mut simplex);
+        assert!(!hit);
+        assert_eq!(3, simplex.len());
+        assert_eq!(Vector3::new(-3., -3., 5.), simplex[2].v);
+        assert_eq!(Vector3::new(2., -10., -1.), simplex[1].v);
+        assert_eq!(Vector3::new(-3., 5., -1.), simplex[0].v);
+        assert_eq!(Vector3::new(90., 30., 40.), v);
+    }
+
+    #[test]
+    fn test_check_origin_tetrahedron_inside() {
+        let mut simplex = vec![
+            sup(3., -3., -1.),
+            sup(-3., -3., -1.),
+            sup(0., 3., -1.),
+            sup(0., 0., 5.),
+        ];
+        let (hit, _) = test_check_origin(&mut simplex);
+        assert!(hit);
+        assert_eq!(4, simplex.len());
+    }
+
+    fn test_check_origin(simplex: &mut Vec<SupportPoint<Point3<f32>>>) -> (bool, Vector3<f32>) {
+        let mut v = Vector3::zero();
+        let b = SimplexProcessor3::new().check_origin(simplex, &mut v);
+        (b, v)
+    }
+
+    fn test_check_side(
+        simplex: &mut Vec<SupportPoint<Point3<f32>>>,
+        above: bool,
+        ignore: bool,
+    ) -> Vector3<f32> {
+        let ab = simplex[1].v - simplex[2].v;
+        let ac = simplex[0].v - simplex[2].v;
+        let ao = simplex[2].v.neg();
+        let abc = ab.cross(ac);
+        let mut v = Vector3::zero();
+        check_side(&abc, &ab, &ac, &ao, simplex, &mut v, above, ignore);
+        v
+    }
+
+    fn sup(x: f32, y: f32, z: f32) -> SupportPoint<Point3<f32>> {
+        let mut s = SupportPoint::new();
+        s.v = Vector3::new(x, y, z);
+        s
+    }
+}

--- a/src/algorithm/mod.rs
+++ b/src/algorithm/mod.rs
@@ -1,0 +1,3 @@
+//! Collision detection algorithms
+
+pub mod minkowski;

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -1,0 +1,72 @@
+//! Collision contact manifold
+
+use cgmath::prelude::*;
+
+/// Collision strategy to use for collisions.
+///
+/// This is used both to specify what collision strategy to use for each shape, and also each
+/// found contact will have this returned on it, detailing what data is relevant in the
+/// [`Contact`](struct.Contact.html).
+#[derive(Debug, PartialEq, Clone, PartialOrd)]
+pub enum CollisionStrategy {
+    /// Compute full contact manifold for the collision
+    FullResolution,
+
+    /// Only report that a collision occurred, skip computing contact information for the collision.
+    CollisionOnly,
+}
+
+/// Contact manifold for a single collision contact point.
+///
+/// # Type parameters
+///
+/// - `P`: cgmath point type
+#[derive(Debug, Clone)]
+pub struct Contact<P: EuclideanSpace> {
+    /// The collision strategy used for this contact.
+    pub strategy: CollisionStrategy,
+
+    /// The collision normal. Only applicable if the collision strategy is not `CollisionOnly`
+    pub normal: P::Diff,
+
+    /// The penetration depth. Only applicable if the collision strategy is not `CollisionOnly`
+    pub penetration_depth: P::Scalar,
+
+    /// The contact point. Only applicable if the collision strategy is not `CollisionOnly`
+    pub contact_point: P,
+}
+
+impl<P> Contact<P>
+where
+    P: EuclideanSpace,
+    P::Diff: VectorSpace + Zero,
+{
+    /// Create a new contact manifold, with default collision normal and penetration depth
+    pub fn new(strategy: CollisionStrategy) -> Self {
+        Self::new_impl(strategy, P::Diff::zero(), P::Scalar::zero())
+    }
+
+    /// Create a new contact manifold, with the given collision normal and penetration depth
+    pub fn new_impl(
+        strategy: CollisionStrategy,
+        normal: P::Diff,
+        penetration_depth: P::Scalar,
+    ) -> Self {
+        Self::new_with_point(strategy, normal, penetration_depth, P::origin())
+    }
+
+    /// Create a new contact manifold, complete with contact point
+    pub fn new_with_point(
+        strategy: CollisionStrategy,
+        normal: P::Diff,
+        penetration_depth: P::Scalar,
+        contact_point: P,
+    ) -> Self {
+        Self {
+            strategy,
+            normal,
+            penetration_depth,
+            contact_point,
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,7 @@ extern crate serde_derive;
 // Re-exports
 
 pub use bound::*;
+pub use contact::*;
 pub use frustum::*;
 pub use line::*;
 pub use plane::Plane;
@@ -59,6 +60,7 @@ pub use volume::*;
 pub mod prelude;
 pub mod dbvt;
 pub mod primitive;
+pub mod algorithm;
 
 // Modules
 
@@ -69,3 +71,4 @@ mod plane;
 mod ray;
 mod line;
 mod volume;
+mod contact;


### PR DESCRIPTION
Gilbert-Johnson-Keerthi algorithm is used to do collision detection on arbitrary shape pairs.
Expanding Polytope Algorithm is used to supplement GJK with actual contact manifold computation, as GJK don't do that.