### PR TITLE
Exactly overlapping identical shapes caused degeneracy in GJK

### DIFF
--- a/src/algorithm/minkowski/gjk/simplex/simplex2d.rs
+++ b/src/algorithm/minkowski/gjk/simplex/simplex2d.rs
@@ -58,6 +58,9 @@ where
             let ab = b - a;
 
             *d = triple_product(&ab, &ao, &ab);
+            if ulps_eq!(*d, Vector2::zero()) {
+                *d = Vector2::new(-ab.y, ab.x);
+            }
         }
         // 0-1 point means we can't really do anything
         false

--- a/src/algorithm/minkowski/gjk/simplex/simplex3d.rs
+++ b/src/algorithm/minkowski/gjk/simplex/simplex3d.rs
@@ -3,6 +3,7 @@ use std::ops::Neg;
 
 use cgmath::{BaseFloat, Point3, Vector3};
 use cgmath::prelude::*;
+use num::cast;
 
 use super::SimplexProcessor;
 use algorithm::minkowski::SupportPoint;
@@ -88,6 +89,9 @@ where
             let ab = b - a;
 
             *v = cross_aba(&ab, &ao);
+            if ulps_eq!(*v, Vector3::zero()) {
+                v.x = cast(0.1).unwrap();
+            }
         }
         // 0-1 points
         false

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #![crate_type = "rlib"]
 #![crate_type = "dylib"]
 #![deny(missing_docs, trivial_casts, unsafe_code, unstable_features, unused_import_braces,
-       unused_qualifications)]
+        unused_qualifications)]
 
 //! Companion library to cgmath, dealing with collision detection centric data structures and
 //! algorithms.


### PR DESCRIPTION
The cause was a dual one: the first search vector was the zero vector, causing the support points to be the zero vector also.
The second cause was that the lines between the support points passed through the origin, which cause the search vector to again become the zero vector.

Fixes #51.