### PR TITLE
Fix for subtract overflow in Aabb/Point containment for unsigned Base…

### DIFF
--- a/src/volume/aabb/aabb2.rs
+++ b/src/volume/aabb/aabb2.rs
@@ -93,9 +93,7 @@ impl<S: BaseNum> fmt::Debug for Aabb2<S> {
 impl<S: BaseNum> Contains<Point2<S>> for Aabb2<S> {
     #[inline]
     fn contains(&self, p: &Point2<S>) -> bool {
-        let v_min = p - self.min();
-        let v_max = self.max() - p;
-        v_min.x >= S::zero() && v_min.y >= S::zero() && v_max.x > S::zero() && v_max.y > S::zero()
+        self.min.x <= p.x && p.x < self.max.x && self.min.y <= p.y && p.y < self.max.y
     }
 }
 

--- a/src/volume/aabb/aabb3.rs
+++ b/src/volume/aabb/aabb3.rs
@@ -105,10 +105,8 @@ impl<S: BaseNum> fmt::Debug for Aabb3<S> {
 impl<S: BaseNum> Contains<Point3<S>> for Aabb3<S> {
     #[inline]
     fn contains(&self, p: &Point3<S>) -> bool {
-        let v_min = p - self.min();
-        let v_max = self.max() - p;
-        v_min.x >= S::zero() && v_min.y >= S::zero() && v_min.z >= S::zero() && v_max.x > S::zero()
-            && v_max.y > S::zero() && v_max.z > S::zero()
+        self.min.x <= p.x && p.x < self.max.x && self.min.y <= p.y && p.y < self.max.y
+            && self.min.z <= p.z && p.z < self.max.z
     }
 }
 

--- a/tests/aabb.rs
+++ b/tests/aabb.rs
@@ -293,6 +293,14 @@ fn test_aabb2_contains_point2() {
 
     assert!(aabb.contains(&inside));
     assert!(!aabb.contains(&outside));
+
+    let aabb = Aabb2::<usize>::new(Point2::new(0, 0), Point2::new(10, 10));
+
+    let inside = Point2::new(2, 2);
+    let outside = Point2::new(11, 11);
+
+    assert!(aabb.contains(&inside));
+    assert!(!aabb.contains(&outside));
 }
 
 #[test]
@@ -327,6 +335,14 @@ fn test_aabb3_contains_point3() {
 
     let inside = Point3::new(3., 3., 3.);
     let outside = Point3::new(11., 11., 11.);
+
+    assert!(aabb.contains(&inside));
+    assert!(!aabb.contains(&outside));
+
+    let aabb = Aabb3::<usize>::new(Point3::new(0, 0, 0), Point3::new(10, 10, 10));
+
+    let inside = Point3::new(3, 3, 3);
+    let outside = Point3::new(11, 11, 11);
 
     assert!(aabb.contains(&inside));
     assert!(!aabb.contains(&outside));


### PR DESCRIPTION
…Nums

Fixes issue #53.

The upper bound check is a strict inequality to avoid breaking the test
in `tests/aabb.rs` (line 66) which indicates that an aabb does *not*
contain `aabb.max()`.